### PR TITLE
8_regression_models.ipynb

### DIFF
--- a/Notebook/8_regression_models.ipynb
+++ b/Notebook/8_regression_models.ipynb
@@ -1,0 +1,1769 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 383,
+   "id": "5252916e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.dummy import DummyRegressor\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "from sklearn.metrics import mean_squared_error, r2_score\n",
+    "from pathlib import Path\n",
+    "import os\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 384,
+   "id": "60b4319e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\turks\\OneDrive\\Masaüstü\\Capstone Project\\Notebook\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check and change the current working directory - A.F.\n",
+    "print(os.getcwd())\n",
+    "os.chdir(Path().resolve())\n",
+    "# read in data set with first column (district name) set to index\n",
+    "df = pd.read_excel(\"../Data/cleaned_data_encoded.xlsx\", index_col =0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 385,
+   "id": "8ce9bc69",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(223, 23)"
+      ]
+     },
+     "execution_count": 385,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 386,
+   "id": "af4efcbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns_to_drop = [\"dropout_rate_pct\",\"still_in_school_pct\",\"in_district_expenditures\",\n",
+    "                   'non_grad_completers_pct', 'hs_equivalency_pct',\n",
+    "    \"overall_classification_Not requiring assistance or intervention\",\n",
+    "    \"overall_classification_Requiring assistance or intervention\",\n",
+    "    \"reason_for_classification_In need of broad/comprehensive support\",\n",
+    "    \"reason_for_classification_In need of focused/targeted support\",\n",
+    "    \"reason_for_classification_Limited or no progress toward targets\",\n",
+    "    \"reason_for_classification_Meeting or exceeding targets\",\n",
+    "    \"reason_for_classification_Moderate progress toward targets\",\n",
+    "    \"reason_for_classification_Substantial progress toward targets\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c44597c6",
+   "metadata": {},
+   "source": [
+    "## ET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 387,
+   "id": "4e875425",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop the columns_to_drop from df dataset\n",
+    "df = df.drop(columns=columns_to_drop)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 388,
+   "id": "355d132d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>english_learners_pct</th>\n",
+       "      <th>students_with_disabilities_pct</th>\n",
+       "      <th>progress_toward_improvement_targets_pct</th>\n",
+       "      <th>in_district_expenditures_per_pupil</th>\n",
+       "      <th>graduation_rate_pct</th>\n",
+       "      <th>student_teacher_ratio</th>\n",
+       "      <th>experienced_teachers_pct</th>\n",
+       "      <th>DOR_income_per_capita</th>\n",
+       "      <th>log_in_district_expenditures</th>\n",
+       "      <th>needs_income_avg_pct</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>district_name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Abington</th>\n",
+       "      <td>11.0</td>\n",
+       "      <td>17.8</td>\n",
+       "      <td>39</td>\n",
+       "      <td>16609.95</td>\n",
+       "      <td>88.9</td>\n",
+       "      <td>13.9</td>\n",
+       "      <td>81.3</td>\n",
+       "      <td>37848.0</td>\n",
+       "      <td>17.387952</td>\n",
+       "      <td>40.85</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Acton-Boxborough</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>15.5</td>\n",
+       "      <td>85</td>\n",
+       "      <td>19407.68</td>\n",
+       "      <td>96.1</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>88.3</td>\n",
+       "      <td>69189.5</td>\n",
+       "      <td>18.426312</td>\n",
+       "      <td>20.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Agawam</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>18.3</td>\n",
+       "      <td>46</td>\n",
+       "      <td>20414.91</td>\n",
+       "      <td>88.0</td>\n",
+       "      <td>12.5</td>\n",
+       "      <td>89.4</td>\n",
+       "      <td>31126.0</td>\n",
+       "      <td>18.091600</td>\n",
+       "      <td>46.05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Amesbury</th>\n",
+       "      <td>2.7</td>\n",
+       "      <td>23.7</td>\n",
+       "      <td>47</td>\n",
+       "      <td>22338.70</td>\n",
+       "      <td>88.3</td>\n",
+       "      <td>10.6</td>\n",
+       "      <td>89.0</td>\n",
+       "      <td>41139.0</td>\n",
+       "      <td>17.503544</td>\n",
+       "      <td>40.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Amherst-Pelham</th>\n",
+       "      <td>7.3</td>\n",
+       "      <td>24.2</td>\n",
+       "      <td>33</td>\n",
+       "      <td>26177.60</td>\n",
+       "      <td>90.9</td>\n",
+       "      <td>10.2</td>\n",
+       "      <td>81.3</td>\n",
+       "      <td>34325.0</td>\n",
+       "      <td>17.296413</td>\n",
+       "      <td>36.90</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  english_learners_pct  students_with_disabilities_pct  \\\n",
+       "district_name                                                            \n",
+       "Abington                          11.0                            17.8   \n",
+       "Acton-Boxborough                   6.2                            15.5   \n",
+       "Agawam                             6.2                            18.3   \n",
+       "Amesbury                           2.7                            23.7   \n",
+       "Amherst-Pelham                     7.3                            24.2   \n",
+       "\n",
+       "                  progress_toward_improvement_targets_pct  \\\n",
+       "district_name                                               \n",
+       "Abington                                               39   \n",
+       "Acton-Boxborough                                       85   \n",
+       "Agawam                                                 46   \n",
+       "Amesbury                                               47   \n",
+       "Amherst-Pelham                                         33   \n",
+       "\n",
+       "                  in_district_expenditures_per_pupil  graduation_rate_pct  \\\n",
+       "district_name                                                               \n",
+       "Abington                                    16609.95                 88.9   \n",
+       "Acton-Boxborough                            19407.68                 96.1   \n",
+       "Agawam                                      20414.91                 88.0   \n",
+       "Amesbury                                    22338.70                 88.3   \n",
+       "Amherst-Pelham                              26177.60                 90.9   \n",
+       "\n",
+       "                  student_teacher_ratio  experienced_teachers_pct  \\\n",
+       "district_name                                                       \n",
+       "Abington                           13.9                      81.3   \n",
+       "Acton-Boxborough                   13.0                      88.3   \n",
+       "Agawam                             12.5                      89.4   \n",
+       "Amesbury                           10.6                      89.0   \n",
+       "Amherst-Pelham                     10.2                      81.3   \n",
+       "\n",
+       "                  DOR_income_per_capita  log_in_district_expenditures  \\\n",
+       "district_name                                                           \n",
+       "Abington                        37848.0                     17.387952   \n",
+       "Acton-Boxborough                69189.5                     18.426312   \n",
+       "Agawam                          31126.0                     18.091600   \n",
+       "Amesbury                        41139.0                     17.503544   \n",
+       "Amherst-Pelham                  34325.0                     17.296413   \n",
+       "\n",
+       "                  needs_income_avg_pct  \n",
+       "district_name                           \n",
+       "Abington                         40.85  \n",
+       "Acton-Boxborough                 20.10  \n",
+       "Agawam                           46.05  \n",
+       "Amesbury                         40.10  \n",
+       "Amherst-Pelham                   36.90  "
+      ]
+     },
+     "execution_count": 388,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 389,
+   "id": "88a3011e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No duplicate columns found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#find duplicate columns\n",
+    "duplicate_columns = df.columns[df.columns.duplicated()].tolist()\n",
+    "if duplicate_columns:\n",
+    "    print(\"Duplicate columns found:\", duplicate_columns)\n",
+    "else:\n",
+    "    print(\"No duplicate columns found.\")\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 390,
+   "id": "5a760b63",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Index(['english_learners_pct', 'students_with_disabilities_pct',\n",
+       "        'progress_toward_improvement_targets_pct',\n",
+       "        'in_district_expenditures_per_pupil', 'graduation_rate_pct',\n",
+       "        'student_teacher_ratio', 'experienced_teachers_pct',\n",
+       "        'DOR_income_per_capita', 'log_in_district_expenditures',\n",
+       "        'needs_income_avg_pct'],\n",
+       "       dtype='object'),\n",
+       " (223, 10))"
+      ]
+     },
+     "execution_count": 390,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.columns, df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 391,
+   "id": "f807f465",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "english_learners_pct                       float64\n",
+       "students_with_disabilities_pct             float64\n",
+       "progress_toward_improvement_targets_pct      int64\n",
+       "in_district_expenditures_per_pupil         float64\n",
+       "graduation_rate_pct                        float64\n",
+       "student_teacher_ratio                      float64\n",
+       "experienced_teachers_pct                   float64\n",
+       "DOR_income_per_capita                      float64\n",
+       "log_in_district_expenditures               float64\n",
+       "needs_income_avg_pct                       float64\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 391,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 392,
+   "id": "75435300",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>english_learners_pct</th>\n",
+       "      <th>students_with_disabilities_pct</th>\n",
+       "      <th>progress_toward_improvement_targets_pct</th>\n",
+       "      <th>in_district_expenditures_per_pupil</th>\n",
+       "      <th>graduation_rate_pct</th>\n",
+       "      <th>student_teacher_ratio</th>\n",
+       "      <th>experienced_teachers_pct</th>\n",
+       "      <th>DOR_income_per_capita</th>\n",
+       "      <th>log_in_district_expenditures</th>\n",
+       "      <th>needs_income_avg_pct</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>district_name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>North Brookfield</th>\n",
+       "      <td>5.0</td>\n",
+       "      <td>24.6</td>\n",
+       "      <td>15</td>\n",
+       "      <td>20008.84</td>\n",
+       "      <td>66.7</td>\n",
+       "      <td>10.8</td>\n",
+       "      <td>74.7</td>\n",
+       "      <td>30230.0</td>\n",
+       "      <td>15.985920</td>\n",
+       "      <td>57.20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Weston</th>\n",
+       "      <td>3.3</td>\n",
+       "      <td>17.2</td>\n",
+       "      <td>86</td>\n",
+       "      <td>29581.26</td>\n",
+       "      <td>95.0</td>\n",
+       "      <td>11.9</td>\n",
+       "      <td>82.6</td>\n",
+       "      <td>333105.0</td>\n",
+       "      <td>17.904114</td>\n",
+       "      <td>17.75</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  english_learners_pct  students_with_disabilities_pct  \\\n",
+       "district_name                                                            \n",
+       "North Brookfield                   5.0                            24.6   \n",
+       "Weston                             3.3                            17.2   \n",
+       "\n",
+       "                  progress_toward_improvement_targets_pct  \\\n",
+       "district_name                                               \n",
+       "North Brookfield                                       15   \n",
+       "Weston                                                 86   \n",
+       "\n",
+       "                  in_district_expenditures_per_pupil  graduation_rate_pct  \\\n",
+       "district_name                                                               \n",
+       "North Brookfield                            20008.84                 66.7   \n",
+       "Weston                                      29581.26                 95.0   \n",
+       "\n",
+       "                  student_teacher_ratio  experienced_teachers_pct  \\\n",
+       "district_name                                                       \n",
+       "North Brookfield                   10.8                      74.7   \n",
+       "Weston                             11.9                      82.6   \n",
+       "\n",
+       "                  DOR_income_per_capita  log_in_district_expenditures  \\\n",
+       "district_name                                                           \n",
+       "North Brookfield                30230.0                     15.985920   \n",
+       "Weston                         333105.0                     17.904114   \n",
+       "\n",
+       "                  needs_income_avg_pct  \n",
+       "district_name                           \n",
+       "North Brookfield                 57.20  \n",
+       "Weston                           17.75  "
+      ]
+     },
+     "execution_count": 392,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#find the schools name Weston and NorthBrookfield\n",
+    "df[df.index.isin(['Weston', 'North Brookfield'])]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 393,
+   "id": "0aa5c34e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Drop these 2 rows \n",
+    "df = df.drop(index=['Weston', 'North Brookfield'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 394,
+   "id": "d4329ed8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(221, 10)"
+      ]
+     },
+     "execution_count": 394,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "568d77b6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13cfa531",
+   "metadata": {},
+   "source": [
+    "#### create logit transformation of graduation_rate_pct\n",
+    "p = df['graduation_rate_pct'] / 100\n",
+    "\n",
+    "eps = 1e-6  # to avoid division by zero when p=0 or 1\n",
+    "df['logit_graduation_rate_pct'] = np.log((p.clip(eps, 1-eps)) / (1 - p.clip(eps, 1-eps)))\n",
+    "\n",
+    "#### drop graduation_rate_pct column\n",
+    "df = df.drop(columns=['graduation_rate_pct'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 395,
+   "id": "9d4bea13",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['english_learners_pct', 'students_with_disabilities_pct',\n",
+       "       'progress_toward_improvement_targets_pct',\n",
+       "       'in_district_expenditures_per_pupil', 'graduation_rate_pct',\n",
+       "       'student_teacher_ratio', 'experienced_teachers_pct',\n",
+       "       'DOR_income_per_capita', 'log_in_district_expenditures',\n",
+       "       'needs_income_avg_pct'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 395,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 396,
+   "id": "5d759b0c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>english_learners_pct</th>\n",
+       "      <th>students_with_disabilities_pct</th>\n",
+       "      <th>progress_toward_improvement_targets_pct</th>\n",
+       "      <th>in_district_expenditures_per_pupil</th>\n",
+       "      <th>graduation_rate_pct</th>\n",
+       "      <th>student_teacher_ratio</th>\n",
+       "      <th>experienced_teachers_pct</th>\n",
+       "      <th>DOR_income_per_capita</th>\n",
+       "      <th>log_in_district_expenditures</th>\n",
+       "      <th>needs_income_avg_pct</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>district_name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Abington</th>\n",
+       "      <td>11.0</td>\n",
+       "      <td>17.8</td>\n",
+       "      <td>39</td>\n",
+       "      <td>16609.95</td>\n",
+       "      <td>88.9</td>\n",
+       "      <td>13.9</td>\n",
+       "      <td>81.3</td>\n",
+       "      <td>37848.0</td>\n",
+       "      <td>17.387952</td>\n",
+       "      <td>40.85</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Acton-Boxborough</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>15.5</td>\n",
+       "      <td>85</td>\n",
+       "      <td>19407.68</td>\n",
+       "      <td>96.1</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>88.3</td>\n",
+       "      <td>69189.5</td>\n",
+       "      <td>18.426312</td>\n",
+       "      <td>20.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Agawam</th>\n",
+       "      <td>6.2</td>\n",
+       "      <td>18.3</td>\n",
+       "      <td>46</td>\n",
+       "      <td>20414.91</td>\n",
+       "      <td>88.0</td>\n",
+       "      <td>12.5</td>\n",
+       "      <td>89.4</td>\n",
+       "      <td>31126.0</td>\n",
+       "      <td>18.091600</td>\n",
+       "      <td>46.05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Amesbury</th>\n",
+       "      <td>2.7</td>\n",
+       "      <td>23.7</td>\n",
+       "      <td>47</td>\n",
+       "      <td>22338.70</td>\n",
+       "      <td>88.3</td>\n",
+       "      <td>10.6</td>\n",
+       "      <td>89.0</td>\n",
+       "      <td>41139.0</td>\n",
+       "      <td>17.503544</td>\n",
+       "      <td>40.10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Amherst-Pelham</th>\n",
+       "      <td>7.3</td>\n",
+       "      <td>24.2</td>\n",
+       "      <td>33</td>\n",
+       "      <td>26177.60</td>\n",
+       "      <td>90.9</td>\n",
+       "      <td>10.2</td>\n",
+       "      <td>81.3</td>\n",
+       "      <td>34325.0</td>\n",
+       "      <td>17.296413</td>\n",
+       "      <td>36.90</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  english_learners_pct  students_with_disabilities_pct  \\\n",
+       "district_name                                                            \n",
+       "Abington                          11.0                            17.8   \n",
+       "Acton-Boxborough                   6.2                            15.5   \n",
+       "Agawam                             6.2                            18.3   \n",
+       "Amesbury                           2.7                            23.7   \n",
+       "Amherst-Pelham                     7.3                            24.2   \n",
+       "\n",
+       "                  progress_toward_improvement_targets_pct  \\\n",
+       "district_name                                               \n",
+       "Abington                                               39   \n",
+       "Acton-Boxborough                                       85   \n",
+       "Agawam                                                 46   \n",
+       "Amesbury                                               47   \n",
+       "Amherst-Pelham                                         33   \n",
+       "\n",
+       "                  in_district_expenditures_per_pupil  graduation_rate_pct  \\\n",
+       "district_name                                                               \n",
+       "Abington                                    16609.95                 88.9   \n",
+       "Acton-Boxborough                            19407.68                 96.1   \n",
+       "Agawam                                      20414.91                 88.0   \n",
+       "Amesbury                                    22338.70                 88.3   \n",
+       "Amherst-Pelham                              26177.60                 90.9   \n",
+       "\n",
+       "                  student_teacher_ratio  experienced_teachers_pct  \\\n",
+       "district_name                                                       \n",
+       "Abington                           13.9                      81.3   \n",
+       "Acton-Boxborough                   13.0                      88.3   \n",
+       "Agawam                             12.5                      89.4   \n",
+       "Amesbury                           10.6                      89.0   \n",
+       "Amherst-Pelham                     10.2                      81.3   \n",
+       "\n",
+       "                  DOR_income_per_capita  log_in_district_expenditures  \\\n",
+       "district_name                                                           \n",
+       "Abington                        37848.0                     17.387952   \n",
+       "Acton-Boxborough                69189.5                     18.426312   \n",
+       "Agawam                          31126.0                     18.091600   \n",
+       "Amesbury                        41139.0                     17.503544   \n",
+       "Amherst-Pelham                  34325.0                     17.296413   \n",
+       "\n",
+       "                  needs_income_avg_pct  \n",
+       "district_name                           \n",
+       "Abington                         40.85  \n",
+       "Acton-Boxborough                 20.10  \n",
+       "Agawam                           46.05  \n",
+       "Amesbury                         40.10  \n",
+       "Amherst-Pelham                   36.90  "
+      ]
+     },
+     "execution_count": 396,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 397,
+   "id": "dacaceb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X_train shape: (176, 9)\n",
+      "X_test shape: (45, 9)\n",
+      "y_train shape: (176,)\n",
+      "y_test shape: (45,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# E.T.\n",
+    "# test train splitfrom sklearn.model_selection import train_test_split\n",
+    "\n",
+    "# Define features and target variable\n",
+    "X = df.drop(columns=['graduation_rate_pct'])\n",
+    "y = df['graduation_rate_pct']\n",
+    "# Split the data into training and testing sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+    "# Print the shapes of the resulting datasets\n",
+    "print(f\"X_train shape: {X_train.shape}\")\n",
+    "print(f\"X_test shape: {X_test.shape}\")\n",
+    "print(f\"y_train shape: {y_train.shape}\")\n",
+    "print(f\"y_test shape: {y_test.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 398,
+   "id": "05978637",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjMAAAHFCAYAAAAHcXhbAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaWJJREFUeJzt3Xl4U1X+P/B3kmbtvi90L2UtVKTIprIoICAq6LiBgOB3VNABFFfGAZcBhJ+IMwq4DYIIigqIoAjIIkKBsu9bKU1LN7ovadomOb8/SiOhLZRSepP0/XrM85ibm3s/Nze07557zrkyIYQAERERkYOSS10AERER0c1gmCEiIiKHxjBDREREDo1hhoiIiBwawwwRERE5NIYZIiIicmgMM0REROTQGGaIiIjIoTHMEBERkUNjmHECX331FWQymfWh0WgQFBSEfv36YdasWcjJyan1nhkzZkAmk93QfgwGA2bMmIFt27bd0Pvq2ldkZCTuv//+G9rO9Sxfvhzz58+v8zWZTIYZM2Y06f6a2u+//46EhAS4urpCJpNhzZo111w/Ozsbb775Jm677TZ4eHhApVIhNDQUI0aMwNq1a2E2m5ul7m3btkEmk93w9+JGzZw5s87PpLn2X5exY8fa/NtTqVSIiYnB1KlTUVxc3KhtZmRkYMaMGTh06FDTFoum+3dw4cIFm+O+1uPChQs3ta+xY8ciMjKyUe+t+dl4szU01p49ezB8+HCEh4dDrVYjMDAQPXv2xMsvv9yo7f3yyy92/3NMMoIc3uLFiwUAsXjxYpGYmCj++OMP8cMPP4jJkycLT09P4ePjIzZt2mTznrS0NJGYmHhD+7l06ZIAIKZPn35D76trXxEREWLo0KE3tJ3rGTp0qIiIiKjztcTERJGWltak+2tKFotF+Pj4iB49eojNmzeLxMREkZ+fX+/6iYmJwt/fX/j5+Ym33npLrF+/Xmzfvl18/fXX4tFHHxUKhUJ88cUXzVL71q1bBQCxdevWW7ofV1dXMWbMmFrLi4qKRGJioigqKrql+6/LmDFjhFarFYmJiSIxMVH8+uuvYvz48QKAGDBgQKO2mZSUZP333NSa6t+B0Wi0HnPNo0uXLiI6OrrWcqPReFP7OnfunDhw4ECj3puTk9MkNTTGunXrhFwuF/379xcrVqwQ27ZtEytWrBAvv/yyaNWqVaO2OXHiRMFf23VzkTJIUdOKi4tDQkKC9fnDDz+MKVOm4M4778SIESNw9uxZBAYGAgBCQ0MRGhp6S+sxGAzQ6XTNsq/r6dGjh6T7v56MjAzk5+dj+PDhuOeee665bmFhIR566CG4ublh586dCA4Otnl91KhROHLkCPLy8q65nfLycmg0mhtuobM3Hh4ekp5fuVxus//77rsP58+fx6ZNm5CSkoKoqCjJartaU31OarW61rY8PDxQWVl53X2Ul5dDq9U2eF8xMTGNqhEA/P394e/v3+j334w5c+YgKioKv/32G1xc/vpV+/jjj2POnDmS1OTMeJnJyYWHh+ODDz5ASUkJPv30U+vyui79bNmyBX379oWvry+0Wi3Cw8Px8MMPw2Aw4MKFC9YfCm+//ba1CXns2LE22ztw4AAeeeQReHt7W38IXeuS1urVq9G5c2doNBpER0fjP//5j83r9TUTX31poW/fvli/fj1SU1Ntmrhr1NW8fuzYMTz44IPw9vaGRqPBbbfdhiVLltS5nxUrVmDatGkICQmBh4cH7r33Xpw+fbr+D/4Kf/75J+655x64u7tDp9OhV69eWL9+vfX1GTNmWMPea6+9BplMds1m9c8//xzZ2dmYM2dOrSBTo3PnzujXr5/1ec3nuHHjRowbNw7+/v7Q6XSoqKjAuXPn8PTTTyM2NhY6nQ6tWrXCsGHDcPTo0VrbPXXqFO677z7odDr4+fnhueeeQ0lJSa31IiMjrd+NK/Xt2xd9+/a1PjcajXj55Zdx2223wdPTEz4+PujZsyd++uknm/fJZDKUlZVhyZIl1nNbs536LjOtXbsWPXv2hE6ng7u7OwYMGIDExESbdWq+m8ePH8cTTzwBT09PBAYGYty4cSgqKqrzs22Imj8qsrOzrcsa8jlv27YN3bp1AwA8/fTT1mO98ru7b98+PPDAA/Dx8YFGo0GXLl2wcuXKBtV19bZqvhdbt27F888/Dz8/P/j6+mLEiBHIyMho9PHXqLmcvGrVKnTp0gUajQZvv/02AOCTTz7B3XffjYCAALi6uqJTp06YM2cOqqqqbLZR12UmmUyGF154AV9//TXat28PnU6H+Ph4rFu3zma9un5+9O3bF3FxcUhKSsJdd90FnU6H6OhozJ49GxaLxeb9x48fx8CBA6HT6eDv74+JEydi/fr1DbqsmZeXBz8/P5sgU0Mur/2r97vvvkPPnj3h6uoKNzc3DBo0CAcPHrT5HD755BPr8TfVZTxnwTDTAgwZMgQKhQJ//PFHvetcuHABQ4cOhUqlwv/+9z9s2LABs2fPhqurKyorKxEcHIwNGzYAAMaPH4/ExEQkJibirbfestnOiBEj0Lp1a3z//fdYtGjRNes6dOgQJk+ejClTpmD16tXo1asXJk2ahP/3//7fDR/jggUL0Lt3bwQFBVlru/oX15VOnz6NXr164fjx4/jPf/6DVatWoUOHDhg7dmydfzW9+eabSE1NxRdffIHPPvsMZ8+exbBhw67bL2X79u3o378/ioqK8OWXX2LFihVwd3fHsGHD8N133wEAnnnmGaxatQoA8OKLLyIxMRGrV6+ud5ubNm2CQqHAkCFDGvLR2Bg3bhyUSiW+/vpr/PDDD1AqlcjIyICvry9mz56NDRs24JNPPoGLiwu6d+9uE9iys7PRp08fHDt2DAsWLMDXX3+N0tJSvPDCCzdcR42Kigrk5+dj6tSpWLNmDVasWGFtSVy6dKl1vcTERGi1WgwZMsR6bhcsWFDvdpcvX44HH3wQHh4eWLFiBb788ksUFBSgb9+++PPPP2ut//DDD6NNmzb48ccf8frrr2P58uWYMmVKo48rJSUFLi4uiI6Oti5ryOd8++23Y/HixQCAf/7zn9ZjfeaZZwAAW7duRe/evVFYWIhFixbhp59+wm233YbHHnsMX331VaPrfeaZZ6BUKrF8+XLMmTMH27Ztw6hRoxq9vSsdOHAAr7zyCv7xj39gw4YNePjhhwEAycnJePLJJ/H1119j3bp1GD9+PObOnYtnn322Qdtdv349Pv74Y7zzzjv48ccf4ePjg+HDh+P8+fPXfW9WVhZGjhyJUaNGYe3atRg8eDDeeOMNLFu2zLpOZmYm+vTpg9OnT2PhwoVYunQpSkpKGvx979mzJ/bs2YN//OMf2LNnT62QdqWZM2fiiSeeQIcOHbBy5Up8/fXXKCkpwV133YUTJ04AAN566y088sgjAGDzM66+P2haHKmvc9HNq+kzk5SUVO86gYGBon379tbn06dPt7n2+sMPPwgA4tChQ/Vu41p9Zmq2969//ave164UEREhZDJZrf0NGDBAeHh4iLKyMptjS0lJsVmvrn4a1+ozc3Xdjz/+uFCr1UKv19usN3jwYKHT6URhYaHNfoYMGWKz3sqVKwWA6/Y76tGjhwgICBAlJSXWZSaTScTFxYnQ0FBhsViEEEKkpKQIAGLu3LnX3J4QQrRr104EBQXVWm42m0VVVZX1YTabra/VfI6jR4++7vZNJpOorKwUsbGxYsqUKdblr732Wr3n7OpzERERUWf/lj59+og+ffpcc99VVVVi/PjxokuXLjav1ddn5urvgtlsFiEhIaJTp042n0FJSYkICAgQvXr1si6r+W7OmTPHZpsTJkwQGo3Gen7qM2bMGOHq6mr9zHNzc8XChQuFXC4Xb7755jXfW9/nfK0+M+3atRNdunQRVVVVNsvvv/9+ERwcbHO8dbn630HN92LChAk2682ZM0cAEJmZmdfc3pX69OkjOnbsaLMsIiJCKBQKcfr06Wu+t+a7u3TpUqFQKGz6i40ZM6bWv2sAIjAwUBQXF1uXZWVlCblcLmbNmlXr+K78+dGnTx8BQOzZs8dmmx06dBCDBg2yPn/llVeETCYTx48ft1lv0KBBDeojlpubK+68804BQAAQSqVS9OrVS8yaNcvm54FerxcuLi7ixRdftHl/SUmJCAoKEo8++qh1GfvM1I8tMy2EEOKar992221QqVT4+9//jiVLljTor5u61PzV1RAdO3ZEfHy8zbInn3wSxcXFOHDgQKP231BbtmzBPffcg7CwMJvlY8eOhcFgqNWq88ADD9g879y5MwAgNTW13n2UlZVhz549eOSRR+Dm5mZdrlAo8NRTTyE9Pb3Bl6oa4qWXXoJSqbQ+rq4ZqPv8mEwmzJw5Ex06dIBKpYKLiwtUKhXOnj2LkydPWtfbunVrvefsZnz//ffo3bs33Nzc4OLiAqVSiS+//NJm3zfi9OnTyMjIwFNPPWXTnO/m5oaHH34Yu3fvhsFgsHlPXefXaDTWORLwamVlZdbP3M/PD88//zwee+wx/Pvf/7ZZr6Gfc33OnTuHU6dOYeTIkdbt1TyGDBmCzMzMRn+fGvP9bqjOnTujTZs2tZYfPHgQDzzwAHx9faFQKKBUKjF69GiYzWacOXPmutvt168f3N3drc8DAwMREBDQoJqDgoJwxx131Krzyvdu374dcXFx6NChg816TzzxxHW3DwC+vr7YsWMHkpKSMHv2bDz44IM4c+YM3njjDXTq1Am5ubkAgN9++w0mkwmjR4+2OacajQZ9+vSRZJSeI2KYaQHKysqQl5eHkJCQeteJiYnB5s2bERAQgIkTJyImJgYxMTH46KOPbmhfN9LkGRQUVO+y63VevVl5eXl11lrzGV29f19fX5vnarUaQHVnxvoUFBRACHFD+2mI8PBwXLp0qdYv5JdffhlJSUlISkqq9zzUtfyll17CW2+9hYceegg///wz9uzZg6SkJMTHx9scX15e3jXPWWOsWrUKjz76KFq1aoVly5YhMTERSUlJGDduHIxGY6O2WfOZ1ve5WywWFBQU2CxvzPmtodVqrZ/7zz//jL59+2LFihWYPXu2zXoN/ZzrU9P/ZurUqTahValUYsKECQBg/QV5o27m+K+nrvOg1+tx11134eLFi/joo4+sv/Rr+oQ0ZL9X1wxU191U783Ly7MOmLhSXcuuJSEhAa+99hq+//57ZGRkYMqUKbhw4YL1cnbNee3WrVut8/rdd981+py2NBzN1AKsX78eZrPZpuNlXe666y7cddddMJvN2LdvH/773/9i8uTJCAwMxOOPP96gfd3IyJisrKx6l9X8sNFoNACq+1Zc6Wb/gfv6+iIzM7PW8ppOj35+fje1fQDw9vaGXC5v8v0MGDAAGzduxC+//GK9hg4AYWFh1pYmlUpV53vrOj/Lli3D6NGjMXPmTJvlubm58PLysj739fW95jm7kkajqXXOarZ55TEvW7YMUVFR+O6772xqq+u9DVXz3anvc5fL5fD29m709q8ml8ttRhEOGDAAXbt2xdtvv42RI0daz0lDP+f61Hxub7zxBkaMGFHnOm3btm3kUdw6dX3n1qxZg7KyMqxatQoRERHW5bdibp3G8vX1tenAXaOu73tDKZVKTJ8+HR9++CGOHTsG4K/z+sMPP9h8FnRj2DLj5PR6PaZOnQpPT88Gd6xTKBTo3r279a+kmks+TfnXGlA9UuDw4cM2y5YvXw53d3fcfvvtAGAdxXDkyBGb9dauXVtrew39qwwA7rnnHmzZsqXWiI2lS5dCp9M1yRBWV1dXdO/eHatWrbKpy2KxYNmyZQgNDa2z+f16nnnmGQQGBuLVV1+t8xf2jZLJZNZzW2P9+vW4ePGizbJ+/frVe86uFhkZWeucnTlzptZlkJqJ5q78hZeVlVVrNBPQ8PPbtm1btGrVCsuXL7e5vFpWVoYff/zROsLpVlGr1fjkk09gNBrx3nvvWZc39HOu799Z27ZtERsbi8OHDyMhIaHOx5WXXexZzfm+8vMQQuDzzz+XqqRaajq713TArfHtt9826P31/dusuaRY0zo7aNAguLi4IDk5ud7zWqOpfwY7E7bMOJFjx45Zr7fm5ORgx44dWLx4MRQKBVavXn3N+RYWLVqELVu2YOjQoQgPD4fRaMT//vc/AMC9994LAHB3d0dERAR++ukn3HPPPfDx8YGfn1+jZ+cMCQnBAw88gBkzZiA4OBjLli3Dpk2b8P7771t/2XTr1g1t27bF1KlTYTKZ4O3tjdWrV9c5IqVTp05YtWoVFi5ciK5du9b6i/lK06dPx7p169CvXz/861//go+PD7755husX78ec+bMgaenZ6OO6WqzZs3CgAED0K9fP0ydOhUqlQoLFizAsWPHsGLFikbN8eLl5YU1a9Zg2LBhiI+Px/PPP48ePXrAzc0NeXl5+OOPP5CVlYVevXo1aHv3338/vvrqK7Rr1w6dO3fG/v37MXfu3FpzA02ePBn/+9//MHToULz33nsIDAzEN998g1OnTtXa5lNPPYVRo0ZhwoQJePjhh5Gamoo5c+bU+g7WDNudMGECHnnkEaSlpeHdd99FcHAwzp49a7Nup06dsG3bNvz8888IDg6Gu7t7nS0Rcrkcc+bMwciRI3H//ffj2WefRUVFBebOnYvCwsJal39uhT59+mDIkCFYvHgxXn/9dURFRTX4c46JiYFWq8U333yD9u3bw83NDSEhIQgJCcGnn36KwYMHY9CgQRg7dixatWqF/Px8nDx5EgcOHMD3339/y4+tKQwYMAAqlQpPPPEEXn31VRiNRixcuLDW5T8p1XzfBw8ejHfeeQeBgYFYvny59fte1/DqKw0aNAihoaEYNmwY2rVrB4vFgkOHDuGDDz6Am5sbJk2aBKA6+L/zzjuYNm0azp8/j/vuuw/e3t7Izs7G3r174erqah3O3qlTJwDA+++/j8GDB0OhUKBz5871tsS2KNL2P6amUNNjv+ahUqlEQECA6NOnj5g5c6bIycmp9Z6rRxglJiaK4cOHi4iICKFWq4Wvr6/o06ePWLt2rc37Nm/eLLp06SLUarUAYB1dUrO9S5cuXXdfQvw1A/APP/wgOnbsKFQqlYiMjBTz5s2r9f4zZ86IgQMHCg8PD+Hv7y9efPFFsX79+lojCvLz88UjjzwivLy8hEwms9kn6hiFdfToUTFs2DDh6ekpVCqViI+PrzWCpGakzPfff2+zvGb0UUNmad2xY4fo37+/cHV1FVqtVvTo0UP8/PPPdW6vIaOZamRlZYk33nhDdO7cWbi6ugqlUilCQkLEsGHDxNKlS21GvFxrxFtBQYEYP368CAgIEDqdTtx5551ix44ddY48OnHihBgwYIDQaDTCx8dHjB8/Xvz000+1zoXFYhFz5swR0dHRQqPRiISEBLFly5Y6tzl79mwRGRkp1Gq1aN++vfj888/r/M4cOnRI9O7dW+h0OgHAup36ZiBes2aN6N69u9BoNMLV1VXcc889YufOnTbr1Pe9rW8U3dVqRjPV5ejRo0Iul4unn35aCHFjn/OKFStEu3bthFKprPXdPXz4sHj00UdFQECAUCqVIigoSPTv318sWrTomrUKUf9opqu/F42Z1bm+0Uz1zfT9888/i/j4eKHRaESrVq3EK6+8In799dda+61vNNPEiRNrbfPqUXT1jWa6us769nPs2DFx77332nzflyxZIgCIw4cP1/1BXPbdd9+JJ598UsTGxgo3NzehVCpFeHi4eOqpp8SJEydqrb9mzRrRr18/4eHhIdRqtYiIiBCPPPKI2Lx5s3WdiooK8cwzzwh/f3/rz7jrfUdbCpkQ1xnmQkRERACAv//971ixYgXy8vLYImJHeJmJiIioDu+88w5CQkIQHR2N0tJSrFu3Dl988QX++c9/MsjYGYYZIiKiOiiVSsydOxfp6ekwmUyIjY3FvHnzrP1dyH7wMhMRERE5NA7NJiIiIofGMENEREQOjWGGiIiIHJrTdwC2WCzIyMiAu7t7oyYoIyIiouYnhEBJSQlCQkKuO0mh04eZjIyMWndGJiIiIseQlpZWa6bsqzl9mKm5V0laWho8PDwkroaIiIgaori4GGFhYQ2655jTh5maS0seHh4MM0RERA6mIV1E2AGYiIiIHBrDDBERETk0hhkiIiJyaAwzRERE5NAYZoiIiMihMcwQERGRQ2OYISIiIofGMENEREQOjWGGiIiIHBrDDBERETk0hhkiIiJyaAwzRERE5NAYZoiIiMihMcwQERGRQ3ORugAiIiJHptfrkZubK9n+/fz8EB4eLtn+7QHDDBERUSPp9Xq0a98e5QaDZDVodTqcOnmyRQcahhkiIqJGys3NRbnBgJGvzUVgeEyz7z9bn4xv3n8Fubm5DDNERETUeIHhMQiN7Sh1GS0WOwATERGRQ2OYISIiIofGMENEREQOjWGGiIiIHBrDDBERETk0hhkiIiJyaAwzRERE5NAYZoiIiMihMcwQERGRQ2OYISIiIofGMENEREQOjWGGiIiIHBrDDBERETk0hhkiIiJyaAwzRERE5NAYZoiIiMihMcwQERGRQ7ObMDNr1izIZDJMnjzZukwIgRkzZiAkJARarRZ9+/bF8ePHpSuSiIiI7I5dhJmkpCR89tln6Ny5s83yOXPmYN68efj444+RlJSEoKAgDBgwACUlJRJVSkRERPZG8jBTWlqKkSNH4vPPP4e3t7d1uRAC8+fPx7Rp0zBixAjExcVhyZIlMBgMWL58uYQVExERkT2RPMxMnDgRQ4cOxb333muzPCUlBVlZWRg4cKB1mVqtRp8+fbBr1656t1dRUYHi4mKbBxERETkvFyl3/u233+LAgQNISkqq9VpWVhYAIDAw0GZ5YGAgUlNT693mrFmz8PbbbzdtoURERGS3JGuZSUtLw6RJk7Bs2TJoNJp615PJZDbPhRC1ll3pjTfeQFFRkfWRlpbWZDUTERGR/ZGsZWb//v3IyclB165drcvMZjP++OMPfPzxxzh9+jSA6haa4OBg6zo5OTm1WmuupFaroVarb13hREREZFcka5m55557cPToURw6dMj6SEhIwMiRI3Ho0CFER0cjKCgImzZtsr6nsrIS27dvR69evaQqm4iIiOyMZC0z7u7uiIuLs1nm6uoKX19f6/LJkydj5syZiI2NRWxsLGbOnAmdTocnn3xSipKJiIjIDknaAfh6Xn31VZSXl2PChAkoKChA9+7dsXHjRri7u0tdGhEREdkJuwoz27Zts3kuk8kwY8YMzJgxQ5J6iIiIyP5JPs8MERER0c1gmCEiIiKHxjBDREREDo1hhoiIiBwawwwRERE5NIYZIiIicmgMM0REROTQGGaIiIjIoTHMEBERkUNjmCEiIiKHxjBDREREDo1hhoiIiBwawwwRERE5NIYZIiIicmgMM0REROTQGGaIiIjIoTHMEBERkUNjmCEiIiKHxjBDREREDo1hhoiIiBwawwwRERE5NIYZIiIicmgMM0REROTQGGaIiIjIoTHMEBERkUNzkboAIiKim6HX65GbmyvJvk+ePCnJfskWwwwRETksvV6Pdu3bo9xgkLSO0tJSSfff0jHMEBGRw8rNzUW5wYCRr81FYHhMs+//5N7t+HXJRzAajc2+b/oLwwwRETm8wPAYhMZ2bPb9ZuuTm32fVBs7ABMREZFDY5ghIiIih8YwQ0RERA6NYYaIiIgcGsMMEREROTSGGSIiInJoDDNERETk0BhmiIiIyKExzBAREZFDY5ghIiIih8YwQ0RERA6NYYaIiIgcGsMMEREROTTeNZuIiOgGCSFQbDShDGq4+LSCScikLqlFY5ghIiJqAIsQOH+pDCczi5FRVA5jlQVANFr936fYWS5wLkmPSF9XdA71hE7FX6/NiZ82ERHRNQghcDanFInn81BoqLIuV8hkkIkqVBqNkGvckF1cgeziChzQF+D2cG90jfCGUsHeHM2BnzIREVE9DJUmrD+aiV+PZaHQUAW1ixwJEd54LCEMz/eNQQ+cRdpHj6OHJgv3tg9AgLsaVWaBPSn5+G5fGorKq66/E7ppbJkhIiKqQ3axEWsPZ8BQaYZcBnSL9MHt4d5QudRuB1DLLegY4okOwR44m1OK7WcuIa+0Et/u1WNwp2CE++gkOIKWgy0zREREV0nJLcMP+9NhqDTDx1WFx7qFoUe0b51B5koymQxtAt3xRLdwBHqoYTRZsPZwBtILDM1UecvEMENERHSFs9kl+PlIBkwWgXAfHR5NCEWAu+aGtuGmccEjt4ci2s8VZovAz4czkV1svEUVE8MMERHRZRfyyrDheBaEANoFueOB+BCoXRSN2paLQo7BcUEI9dai0mzBT4cyUGJkH5pbgWGGiIgIQEZhOdYfyYRFAG0C3DCgQyAU8pubP8ZFIcewziHwd1ejvMqMX49lwWIRTVQx1WCYISKiFq/EWIV1RzJhsghE+uowsGMQ5LKmmQhP5SLHkLggqBRyZBYZsTslr0m2S39hmCEiohatymzBuiOZKK8yw89NhSGdgm+6ReZqXjoV7mkfAABIulCAtHx2CG5KDDNERNRiCSGw5VQOckoqoFUqMKxzyC2b6K5NoDviQjwAAFtO58BksdyS/bREDDNERNRincoqwamsEshkwJBOQfDQKm/p/u6M9YNOpUChoQr7LxTc0n21JAwzRETUIhUaKrH1dA4AoEeUL0K9b/3EdmoXBe6O9QcAJKUWoMBQecv32RIwzBARUYtjtghsOJ6FKrNAKy8tEiK9m23fbQLdEO6jg9kisONsbrPt15kxzBARUYtzQF+A7OIKqF3kGNQxsMlGLjWETCZD37b+kMmqZxrOKCxvtn07K4YZIiJqUfLLKrHnfD4AoE8bf7hrbm0/mbp461ToGFzdGXjnuVwIwblnbgbDDBERtRgWIbDpRDbMono+mXZB7pLVckeUDxRyGTKKjLiQx6HaN4NhhoiIWowj6UXIKjZCpZCjf7sAyJrx8tLV3DVKxId6AgASk/PYOnMTGGaIiKhFKKswITG5evbd3q19Jbm8dLWESB8oFTJcKq1AKltnGo1hhoiIWoQ/zl5CpdmCQA814lp5Sl0OAECrVCAupLqWfamcd6axGGaIiMjp6fMNOJNdChmAfm0DmnX00vV0CfeCXAZcLCxHVpFR6nIcEsMMERE5NYtFYPuZSwCATqGeCPTQSFyRLXeNEm0vd0Tel5ovcTWOiWGGiIic2tGLRcgvq4RGKUfPaF+py6lTQoQPACD5UhlnBW4EhhkiInJaxiozdp+v7vTbI9oXGqVC4orq5uOqQqRv9e0UjqQXSVyN42GYISIip7XnfD6MJgt8XVXoFGIfnX7rEx/qBQA4kVmMKjPvqH0jGGaIiMgpFRoqceRiIQDg7jb+kMvtp9NvXSJ8dfDUKlFpsuB0VonU5TgUhhkiInJKicl5sIjqkBDuc+vviH2zZDIZOl8eMn4kvYiT6N0AhhkiInI62cVGnMkpBQD0jvGTuJqG6xDiAYW8ehK9TA7TbjBJw8zChQvRuXNneHh4wMPDAz179sSvv/5qfV0IgRkzZiAkJARarRZ9+/bF8ePHJayYiIgcwc7kXABAuyB3+LurJa6m4TRKBdoGVg/TPpbBjsANJWmYCQ0NxezZs7Fv3z7s27cP/fv3x4MPPmgNLHPmzMG8efPw8ccfIykpCUFBQRgwYABKSngtkYiI6paaV4a0/HLIZdUjmBxNx5Dqu2mfyylFpYkdgRtC0jAzbNgwDBkyBG3atEGbNm3w73//G25ubti9ezeEEJg/fz6mTZuGESNGIC4uDkuWLIHBYMDy5culLJuIiOyUEAK7Lt9/qXOoFzy10t9/6UYFe2rgpVOiyixwNod/vDeE3fSZMZvN+Pbbb1FWVoaePXsiJSUFWVlZGDhwoHUdtVqNPn36YNeuXfVup6KiAsXFxTYPIiJqGc7mlCKnpAIqhRzdIr2lLqdRZDIZOgRXt86cyOTvsIaQPMwcPXoUbm5uUKvVeO6557B69Wp06NABWVlZAIDAwECb9QMDA62v1WXWrFnw9PS0PsLCwm5p/UREZB/Mlr9aZW4P94JO5SJxRY3XPsgDMgAZhUYUckbg65I8zLRt2xaHDh3C7t278fzzz2PMmDE4ceKE9XXZVTcDE0LUWnalN954A0VFRdZHWlraLaudiIjsx/GMIhSVV0GrVKBLuGO2ytRw07gg/PKMwGyduT7Jw4xKpULr1q2RkJCAWbNmIT4+Hh999BGCgoIAoFYrTE5OTq3Wmiup1Wrr6KiaBxEROTezAJIuFAAA7ojygcpF8l9vN63mUtOprBLOOXMddne2hRCoqKhAVFQUgoKCsGnTJutrlZWV2L59O3r16iVhhUREZG9SSuUorTDBTe2CuBDn+CM22s8VSoUMJUYT55y5DkkvKL755psYPHgwwsLCUFJSgm+//Rbbtm3Dhg0bIJPJMHnyZMycOROxsbGIjY3FzJkzodPp8OSTT0pZNhER2RGZiwqni6tvINkt0hsuCrv7O71RXBRyxPi74VRWCU5nlyDESyt1SXZL0jCTnZ2Np556CpmZmfD09ETnzp2xYcMGDBgwAADw6quvory8HBMmTEBBQQG6d++OjRs3wt3dXcqyiYjIjrjF3wejWQY3tQs6OEmrTI22Qe44lVWCs9ml6BNr//eXkoqkYebLL7+85usymQwzZszAjBkzmqcgIiJyKBUmAY8ejwCo7ivjIneOVpkaYd46aJUKlFeZkVZgQISvq9Ql2SXnOutERNSi/JZcBhc3H+gUwtph1pko5DLEBrgBAE5ncwK9+jDMEBGRQzJUmrD6VBkAoJ2nGQonvQTTJqi6a0VyThlMZt7eoC4MM0RE5JC+TkxFUYUFVQWZiHB13l/yIZ4auKldUGm2QF9gkLocu8QwQ0REDsdQacJnf5wHABTt+hZO2igDoLr/aIx/dV+ZczmlEldjnxhmiIjI4Szfo0deWSUCXRUoO75V6nJuudaX+82cv1QGs4UT6F2NYYaIiByKscpsbZUZ0d4NEM57ialGiJcWWqUCFSYL0nmpqRaGGSIicijf70tDTkkFQjw16BvRMiaSk8tkiAngpab6MMwQEZHDqDRZsGh7davMc31joFQ4cWeZq7T2r77UlHypDBZearLBMENERA5j9cF0XCwsh7+7Go8mhEldTrMK9dZB4yJHeZUZGUXlUpdjVxhmiIjIIZjMFizYlgwAePbuaGiUCokral4KuQxRl0c1nb9UJnE19oVhhoiIHMK6I5lIzTPAW6fEk93DpS5HEtF+l0c15ZZBCF5qqsEwQ0REds9iEfh46zkAwDN3RUOnkvTWgpIJ99FBIZehqLwK+WWVUpdjNxhmiIjI7m04noVzOaXw0LhgdM8IqcuRjMpFjjDv6hFcybm81FSDYYaIiOyaEAL/3VLdKjO2dxTcNUqJK5JW9OVRTSnsN2PFMENERHZty6kcnMwshqtKgad7RUpdjuSi/Ko7AWcVG2E0S1yMnWCYISIiuyWEwH8ut8qM6hkBb1eVxBVJz03tgkAPNQAgs5y/xgGGGSIismN/nsvF4bRCaJRy/N9d0VKXYzdqRjUxzFTjp0BERHarpq/ME3eEw89NLXE19iPSVwcAuGSUAfKWObLrSgwzRERkl/acz8PelHyoFHI8e3eM1OXYFX93NXQqBUxCBk1oB6nLkRzDDBER2aWaeWX+lhCKIE+NxNXYF5lMhojLrTOa6K4SVyM9hhkiIrI7B/UF2HE2Fwq5DM/1YatMXSJ9q0c1aaMTJK5Eeo0KMykpKU1dBxERkdUnl1tlhndphTAfncTV2KdwHx0AAZV/BHINLXuMdqPCTOvWrdGvXz8sW7YMRqOxqWsiIqIW7HhGETafzIFcBkzoy1aZ+miUCviqqu/PdCCzQuJqpNWoMHP48GF06dIFL7/8MoKCgvDss89i7969TV0bERG1QDWtMvd3DrHOdkt1C9RaAAAHslp2w0KjwkxcXBzmzZuHixcvYvHixcjKysKdd96Jjh07Yt68ebh06VJT10lERC3A2ewS/HosCwAwsV9riauxf0Ha6paZI9mVqDRZJK5GOjfVAdjFxQXDhw/HypUr8f777yM5ORlTp05FaGgoRo8ejczMzKaqk4iIWoBPtp6DEMB9HYPQNshd6nLsnpdSwFxWAKNJYF9qvtTlSOamwsy+ffswYcIEBAcHY968eZg6dSqSk5OxZcsWXLx4EQ8++GBT1UlERE7uQm4Z1h7OAAC80J+tMg0hkwHl5w8AALafbrlXRRoVZubNm4dOnTqhV69eyMjIwNKlS5Gamor33nsPUVFR6N27Nz799FMcOHCgqeslIiIntWDbOVgE0K+tP+JaeUpdjsMoT9kPANjWgsNMo+ZAXrhwIcaNG4enn34aQUFBda4THh6OL7/88qaKIyKiliG9wIBVBy4CAF7oHytxNY7FmHIAchlwOrsEGYXlCPHSSl1Ss2tUmDl79ux111GpVBgzZkxjNk9ERC3Mou3JMFkEerf2RdcIb6nLcSgWYylifZQ4nVeFbacv4cnu4VKX1OwadZlp8eLF+P7772st//7777FkyZKbLoqIiFqOrCIjVialAwBeZKtMo3QJqr4J57bTORJXIo1GhZnZs2fDz8+v1vKAgADMnDnzposiIqKW49M/klFptuCOSB/0iPaVuhyH1DW4+t5VO8/ltsgh2o0KM6mpqYiKiqq1PCIiAnq9/qaLIiKiluFSSQVW7K3+vfHiPRzB1FhR3i7wdVWhrNKMQ2mFUpfT7BoVZgICAnDkyJFayw8fPgxfX6ZqIiJqmC/+PA9jlQXxYV64s3XtFn9qGLlMhl6XP78/z+VKXE3za1SYefzxx/GPf/wDW7duhdlshtlsxpYtWzBp0iQ8/vjjTV0jERE5oYKySnydmAoA+Ef/1pDJZBJX5NjubF3dmLCzBYaZRo1meu+995Camop77rkHLi7Vm7BYLBg9ejT7zBARUYMs3pkCQ6UZHYI90L9dgNTlOLzel1tmDqUVosRYBXeNUuKKmk+jwoxKpcJ3332Hd999F4cPH4ZWq0WnTp0QERHR1PUREZETKjZWYfGuCwCAF9kq0yRCvXWI9NXhQp4Be87n494OgVKX1GwaFWZqtGnTBm3atGmqWoiIqIVYsvMCSowmtAl0w6COdU++Sjeud2s/XMjT489zuQwz12M2m/HVV1/h999/R05ODiwW22FgW7ZsaZLiiIjI+ZRWmPDlzhQA1XfGlsvZKtNU7or1wzd79C2u30yjwsykSZPw1VdfYejQoYiLi2PzIBERNdg3u1NRaKhClJ8r7u8cInU5TqVntB9kMuBsTimyi40I9NBIXVKzaFSY+fbbb7Fy5UoMGTKkqeshIiInVl5pxuc7zgMAJvSNgYKtMk3KU6dE51aeOJxehJ3ncjHi9lCpS2oWjRqarVKp0Lo1JzciIqIbs2KvHrmllQj11uKhLq2kLscp1Yxq+vNsy7nU1Kgw8/LLL+Ojjz6CEKKp6yEiIidVYTLj0z+SAQAT+raGUtGoX0F0HXdeMXleS/k93ajLTH/++Se2bt2KX3/9FR07doRSaTuWfdWqVU1SHBEROY/v96Uju7gCwZ4aPNyVrTK3yu0R3lC7yJFTUoFzOaWIDXSXuqRbrlFhxsvLC8OHD2/qWoiIyElVmS1YuK26VebZu6OhdlFIXJHz0igVuCPKBzvO5uLPc7kMM/VZvHhxU9dBRERObPXBi7hYWA4/NzUevyNc6nKcXu/WfthxNhc7z+Xi6d61bwztbBp9wdJkMmHz5s349NNPUVJSAgDIyMhAaWlpkxVHRESOz2S2YMHWcwCqW2U0SrbK3Go1/WZ2n89HldlynbUdX6NaZlJTU3HfffdBr9ejoqICAwYMgLu7O+bMmQOj0YhFixY1dZ1EROSg1h3JxIU8A7x1SjzZna0yzaFDsAe8dUoUGKpwJL0QXSN8pC7plmpUy8ykSZOQkJCAgoICaLVa6/Lhw4fj999/b7LiiIjIsVksAh9fbpV55q5ouKpv6i461EByuQy9LrfO7GgBQ7QbPZpp586dUKlUNssjIiJw8eLFJimMiIgcg16vR25u3b8wd6WV41xOKVyVMsTrCnHgwIEm3ffJkyebdHvOpHeMH9YfycSu5DxMvlfqam6tRoUZi8UCs9lca3l6ejrc3Z2/1zQREVXT6/Vo1749yg2GOl6VIfjp/0AVEIWL277BXe8tv2V1sL9mbT1jfAEAh/SFMFaZnbqvUqPCzIABAzB//nx89tlnAACZTIbS0lJMnz6dtzggImpBcnNzUW4wYORrcxEYHmPz2kWDDLtzlXCRCTz16CNQPfFIk+//5N7t+HXJRzAajU2+bUcX6atDkIcGWcVG7E8tsM4M7IwaFWY+/PBD9OvXDx06dIDRaMSTTz6Js2fPws/PDytWrGjqGomIyM4FhscgNLaj9bkQAtv36gFU4vYIX0RfbiVoatn65FuyXWcgk8nQM8YXqw9eRGJyHsPM1UJCQnDo0CGsWLECBw4cgMViwfjx4zFy5EibDsFERNQyJV8qQ25pJVQKObqEe0ldTovVM/pymDmfJ3Upt1Sju5VrtVqMGzcO48aNa8p6iIjIwQkhsCel+pfnbWFeTt1Xw97V9Js5nFaIsgqT044ma9RRLV269Jqvjx49ulHFEBGR42OrjP0I89GhlZcWFwvLsS+1AH3a+Etd0i3RqDAzadIkm+dVVVUwGAxQqVTQ6XQMM0RELRRbZexPzxhf/LA/HYnJeU4bZho1aV5BQYHNo7S0FKdPn8add97JDsBERC0YW2XsT8/o6ktNztxvptH3ZrpabGwsZs+eXavVhoiIWga2ytinmn4zxy4WocRYJXE1t0aThRkAUCgUyMjIaMpNEhGRg2CrjH0K8dIiwlcHs0Ug6UK+1OXcEo3qM7N27Vqb50IIZGZm4uOPP0bv3r2bpDAiInIcQsDaKhMf5slWGTvTM9oXqXkGJCbnoX+7QKnLaXKNCjMPPfSQzXOZTAZ/f3/0798fH3zwQVPURUREDiSjXHZFq4y31OXQVXrG+OLbpDSn7TfT6HszERER1ThZVN0SEx/mCS1bZexOTSfg4xnFKDJUwVOnlLiiptWkfWaIiKjl0cb2QFGVnK0ydizAQ4MYf1eby4HOpFEtMy+99FKD1503b15jdkFERA5ACAGv3k8AYKuMvesZ44vkS2VIPJ+HgR2DpC6nSTUqzBw8eBAHDhyAyWRC27ZtAQBnzpyBQqHA7bffbl1PJpM1TZVERGSX9mZUQBUYAxeZYKuMnesZ7Ydlu/VITGbLDABg2LBhcHd3x5IlS+DtXf3lLSgowNNPP4277roLL7/8cpMWSURE9kcIgZXHSwAAMe4WtsrYuR7RPgCAU1klyC+rhI+rSuKKmk6j+sx88MEHmDVrljXIAIC3tzfee+89jmYiImohNp3IRkqhCZYKA2LdzVKXQ9fh66ZG20B3AMAeJxvV1KgwU1xcjOzs7FrLc3JyUFJSctNFERGRfbNYBOZvPgsAKNn/M9RslHEINbMBO9sQ7UaFmeHDh+Ppp5/GDz/8gPT0dKSnp+OHH37A+PHjMWLEiKaukYiI7Mxvx7NwIrMYWhcZipPWSF0ONVCPmvs0OVm/mUb1mVm0aBGmTp2KUaNGoaqq+j4PLi4uGD9+PObOndukBRIRkX0xWwQ+3HwGAHB/G1f8PyNb5B1Fj2gfyGTA2ZxS5JQYEeCukbqkJtGolhmdTocFCxYgLy/POrIpPz8fCxYsgKura4O3M2vWLHTr1g3u7u4ICAjAQw89hNOnT9usI4TAjBkzEBISAq1Wi759++L48eONKZuIiJrAuiMZOJNdCg+NCx5o0/Cf+SQ9L50K7YM8AAC7zzvPfZpuatK8zMxMZGZmok2bNnB1dYUQ4obev337dkycOBG7d+/Gpk2bYDKZMHDgQJSVlVnXmTNnDubNm4ePP/4YSUlJCAoKwoABA9g3h4hIAiazBR9d7ivzf3dFw1XFuVcdjbXfjBNdamrUtzAvLw/33HMP2rRpgyFDhiAzMxMA8Mwzz9zQsOwNGzZg7Nix6NixI+Lj47F48WLo9Xrs378fQHWrzPz58zFt2jSMGDECcXFxWLJkCQwGA5YvX96Y0omI6Cb8dCgD53PL4KVT4uk7o6Quhxqh5tYGu52oE3CjwsyUKVOgVCqh1+uh0+msyx977DFs2LCh0cUUFRUBAHx8qsfCp6SkICsrCwMHDrSuo1ar0adPH+zatavObVRUVKC4uNjmQUREN6/KbMFHv1e3yjx7dwzc1I3qdkkSuyPaB3IZkJJbhqwio9TlNIlGhZmNGzfi/fffR2hoqM3y2NhYpKamNqoQIQReeukl3HnnnYiLiwMAZGVlAQACA21vVx4YGGh97WqzZs2Cp6en9REWFtaoeoiIyNaP+9OhzzfAz02FMb0ipC6HGslDo0RcK08AQOL5XImraRqNCjNlZWU2LTI1cnNzoVarG1XICy+8gCNHjmDFihW1Xrv6tghCiHpvlfDGG2+gqKjI+khLS2tUPURE9JcKkxn/3XIOAPBcnxjoVGyVcWQ9nWyIdqPCzN13342lS5dan8tkMlgsFsydOxf9+vW74e29+OKLWLt2LbZu3WrT2hMUVH0jrKtbYXJycmq11tRQq9Xw8PCweRAR0c1ZuS8dFwvLEeihxqgebJVxdD2cbPK8RkXruXPnom/fvti3bx8qKyvx6quv4vjx48jPz8fOnTsbvB0hBF588UWsXr0a27ZtQ1SUbWeyqKgoBAUFYdOmTejSpQsAoLKyEtu3b8f777/fmNKJiOgGGavM+ORyq8zEfq2h4T2YHF63SB8o5DKk5ZcjvcCAUO/aV1scSaNaZjp06IAjR47gjjvuwIABA1BWVoYRI0bg4MGDiImJafB2Jk6ciGXLlmH58uVwd3dHVlYWsrKyUF5eDqC6xWfy5MmYOXMmVq9ejWPHjmHs2LHQ6XR48sknG1M6ERHdoOV79MgqNiLEU4PHurEfojNwU7ugc+jlfjNOcKnphltmqqqqMHDgQHz66ad4++23b2rnCxcuBAD07dvXZvnixYsxduxYAMCrr76K8vJyTJgwAQUFBejevTs2btwId3f3m9o3ERFdX3mlGQu2JQMAXugfC7ULW2WcRc9oXxzUFyLxfB7+luDYIfWGw4xSqcSxY8fq7YB7IxoyyZ5MJsOMGTMwY8aMm94fERHdmK93X0BuaQXCfLT4W0Lo9d9ADqNnjC8WbEvG7uS8aw6scQSNusw0evRofPnll01dCxER2ZHSChMWbT8PAPhH/1goFZzt15kkRPhAqZAho8gIfb5B6nJuSqM6AFdWVuKLL77Apk2bkJCQUOt+TPPmzWuS4oiISDpLdl1Aflklov1cMbxLK6nLoSamVSlwW5gXki4UIDE5DxG+jnufrRsKM+fPn0dkZCSOHTuG22+/HQBw5swZm3UcuZmKiIiqFRur8Nkf1a0yk+6NhQtbZZxSz2jf6jBzPg+P3xEudTmNdkNhJjY2FpmZmdi6dSuA6tsX/Oc//6l3zhciInJMX+5IQVF5FWID3HB/5xCpy6FbpEeML/6z5RwSHbzfzA1F7as77P766682d7gmIiLHV1BWiS//TAEATL63DRRyx/wFR9d3e7g3VC5y5JRU4Hyu4/4+v6l2w4aMRiIiIseycHsySitM6BjigcFxQVKXQ7eQRqnA7eFeABx7vpkbCjMymaxWE5SjNkkREVFtWUVGLNl1AQAwdVBbyNkq4/R6RvsBcOxbG9xQnxkhBMaOHWu9maTRaMRzzz1XazTTqlWrmq5CIiJqNv/dchYVJgu6RXqjbxt/qcuhZtAzxhcfbgb2nHfcfjM3FGbGjBlj83zUqFFNWgwREd0YvV6P3NzcJtlWVqkJ3+69BAB4MEqOgwcPXvc9J0+ebJJ9k3TiwzyhUcqRW1qJszmlaBPoeDPs31CYWbx48a2qg4iIbpBer0e79u1RbmiaCc98738Zbh37oTx5H556f8YNvbe0tLRJaqDmp3ZRICHCB3+ey0Vicp7zhxkiIrIfubm5KDcYMPK1uQgMb/hNfutSVCnD5qzqXwlDe8fDu1/Duguc3Lsdvy75CEaj8ab2T9LqGeNrDTNjekVKXc4NY5ghInJwgeExCI3teFPbOHg4A0AZYgPc0KljcIPfl61Pvqn9kn3oEe0LANidkgeLRThcx29O6UhE1MJlFpXjfG4ZZPjrlxq1LJ1DPaFTKVBoqMKprBKpy7lhDDNERC3crsvzi7QP9oCPq0riakgKSoUc3SJ9ADjmEG2GGSKiFkyfb0B6QTnkMqB7lI/U5ZCEesZUt8o54uR5DDNERC2UEAK7kquHdXdq5QkPrVLiikhKPS9fYtyTkgezxbFm+GeYISJqoc7nliG7uAIucpn1EgO1XB1DPOCudkGJ0YQTGcVSl3NDGGaIiFogi0Vg57nqVpnbwrzgqubg1pbORSHHHVE1/WaaZiLG5sIwQ0TUAp3ILEaBoQoaFzkSIrylLofshKP2m2GYISJqYarMFuy+PGLljigfqJUKiSsie1EzND/pQgFMZovE1TQcwwwRUQtzUF+IskozPDQu6BTqKXU5ZEc6BHvAU6tEaYUJRy8WSV1OgzHMEBG1IIZKE/anFgCovqTgIuevAfqLXC6zDtF3pPlm+C0mImpB9qbko9JsQYC7Gm0d8IaCdOs5Yr8Zhhkiohai0FBpvXTQu7UfZDLHuv8ONY+aMLPvQgEqTY7Rb4ZhhoiohUhMzoNFABE+OoT76KQuh+xUmwB3+LiqUF5lxpH0QqnLaRBOLEBE1AJkFRtxJqcUQHWrDDmXkydPNun22nrLkVgG/PjnUcjzr3050s/PD+Hh4U26/xvFMENE5OSEENh5tnoStPZB7vB3V0tcETWV4vxLAIBRo0Y16XbdugyB78AJ+N+6nZj91LRrrqvV6XDq5ElJAw3DDBGRk7uQZ0B6YTkUchl6XO4PQc6hvLT6tgNDn52Gtp27Ntl2i6uATZmAa1RnTPp4FRT1dK/K1ifjm/dfQW5uLsMMERHdGhbx120L4kM94aHhzSSdkW9IBEJjOzbZ9oQQ2JmXAkOlGQr/KIR623cfK3YAJiJyYiczi5FXVgm1i5w3k6QGk8lkCPXWAgDSCsolrub6GGaIiJxUpcmCXZfnCrkj0gca3raAbkDY5RFvafkGiSu5PoYZIiIntS81H4ZKMzy1SsSHeUldDjmY8MuXlrKKjagwmSWu5toYZoiInFBxeRUO6AsBAHfF+kEh5wR5dGM8tEp4apUQArho55eaGGaIiJzQznO5MFsEQr21iPZzlbocclDh1ktNDDNERNSMMgrLrRPk3R3rz9sWUKPVhBm9nfebYZghInIiQghsP1M9kVpciAcnyKObUjOiKd9QiVKjSeJq6scwQ0TkRE5llSCnpAIqhRw9ojlBHt0cjVKBQI/qQJxWYL+tMwwzREROotJkwc7k6gnyukV6w1XNeVHp5oV52/+lJoYZIiInsSclD2UV1UOxb+NQbGoi4VfMNyOEkLiaujHMEBE5gbzSChxKKwQA9GnjDxcFf7xT0wj21MBFLkNZpRn5ZZVSl1MnftuJiBycEMC2M5dgEUC0nyuiOBSbmpCLQo4Qr+qOwPZ6qYlhhojIwaUb5EgvqL4r9t1t/KUuh5yQ9VKTnU6exzBDROTAZCotjhRW33OpW4Q3PLW8KzY1vZowk15ggNlif/1mGGaIiByYZ6/HYTTL4KlVomuEt9TlkJPyc1NBq1SgyiyQVWyUupxaGGaIiBxUenEVPBIeBADc3caPnX7plpHJZAi7PIGePd5Fm998IiIHZLEILNxXBJnCBUEaC6L93KQuiZxcmB3f2oBhhojIAa1I0uNkbhUsleW4zcd+p5kn51HTbyar2IgKk1niamwxzBAROZisIiNm/3IKAFD4x9dw5US/1Aw8tEp465QQwv7uos0wQ0TkYKavPYaSChNifZQoObBO6nKoBYnwrZ7D6EJemcSV2GKYISJyIBuOZeK349lwkcswIcETEBapS6IWJNK3+lJTap593dqAYYaIyEEUlVfhXz8dBwA81ycGEV6cU4aaVysvLRRyGUorTMizo1sbMMwQETmI2b+eQk5JBaL9XPFC/9ZSl0MtkItCjtDLQ7RT8+xnVBPDDBGRA9h+5hJW7NUDAGaN6ASNUiFxRdRSRdphvxmGGSIiO1doqMQr3x8GAIztFYnu0b4SV0QtWcTlfjMZheUw2UmXLYYZIiI79881x6ovL/m74rX72kldDrVwXlolPLVKWASQY5RJXQ4AhhkiIrv206GLWHckEwq5DB8+ehu0Kl5eImnJZDJr60y20T5ihH1UQUREtWQWleOtNccAAC/2b434MC9pCyK6rCbMZJXbR4zgvJFERHbIYhF49YcjKDaaEB/qiYn9OHqJ7EeYtw4KmQwGM+Di00rqctgyQ0RkjxbvuoAdZ3OhUcox77HboOQdscmOKBVyhHhrAADa6K4SV8MwQ0Rkdw7oCzDrl5MAgGlD2iPGn3fEJvtTM0RbG50gcSUMM0REdqWgrBIvfHMAJovA0E7BGNUjQuqSiOoUcfku2pqwOFSYpL21AcMMEZGdsFgEpqw8hIwiI6L8XDH74U6Qyexj6CvR1XxcVdApBGQuKhy7VCFpLQwzRER2YsG2c9h2+hLULnIsGHk73DW89xLZL5lMhkBt9ax5BzMZZoiIWrxdybmYt+kMAODdh+LQPthD4oqIri9UZ0Fx0hr0DtdKWgfDDBGRxNILDPjHioOwCOCRrqF4NCFM6pKIGiRAI1Cw5Qu091NJWgfDDBGRhEqMVXhmyT7kllaifbAH3n0wTuqSiBwOwwwRkURMZgteXHEQp7JK4O+uxpdjEni7AqJGYJghIpLIu+tOYNvpS9Ao5fhyTAJCvKTtd0DkqBhmiIgk8NXOFCxJTAUAzH/sNnQO9ZK2ICIHxjBDRNTMNp/IxjvrTgAAXh/cDvfFBUtcEZFjY5ghImpGf57NxYTlB2ARwGMJYXj27mipSyJyeJKGmT/++APDhg1DSEgIZDIZ1qxZY/O6EAIzZsxASEgItFot+vbti+PHj0tTLBHRTdpzPg/PLE1CpcmCQR0D8d7wOM7wS9QEJA0zZWVliI+Px8cff1zn63PmzMG8efPw8ccfIykpCUFBQRgwYABKSkqauVIioptzUF+AcV8lwVhlQb+2/vjvE7fzTthETcRFyp0PHjwYgwcPrvM1IQTmz5+PadOmYcSIEQCAJUuWIDAwEMuXL8ezzz7bnKUSETXasYtFGPO/vSirNKNXjC8WjuoKlQuDDFFTkTTMXEtKSgqysrIwcOBA6zK1Wo0+ffpg165d9YaZiooKVFT8dY+I4uLiW14rEUlHr9cjNzdXsv37+fkhPDy83tePpBdizP/2othoQrdIb3wxJgEaJeeSIWpKdhtmsrKyAACBgYE2ywMDA5Gamlrv+2bNmoW33377ltZGRPZBr9ejXfv2KDcYJKtBq9Ph1MmTdQaaxOQ8/N/SfSitMOG2MC/8b2w36FR2+2OXyGHZ/b+qqzvHCSGu2WHujTfewEsvvWR9XlxcjLAw3ueEyBnl5uai3GDAyNfmIjA8ptn3n61Pxjfvv4Lc3NxaYWbDsUxM+vYQKkwW9Iz2xedjEuCmtvsfuUQOyW7/ZQUFBQGobqEJDv5rDoacnJxarTVXUqvVUKvVt7w+IrIfgeExCI3tKHUZAKr/4PryzxT8+5eTEAK4t30gPn6yCy8tEd1CdtsDLSoqCkFBQdi0aZN1WWVlJbZv345evXpJWBkRUd0qTRb8c80xvLe+OsiM6hGORaNuZ5AhusUkbZkpLS3FuXPnrM9TUlJw6NAh+Pj4IDw8HJMnT8bMmTMRGxuL2NhYzJw5EzqdDk8++aSEVRMR1XappAITvtmPpAsFkMmANwa3w//dFc15ZIiagaRhZt++fejXr5/1eU1flzFjxuCrr77Cq6++ivLyckyYMAEFBQXo3r07Nm7cCHd3d6lKJiKq5XB2BZ77dQdySirgrnbBR0/chv7t6r8cTkRNS9Iw07dvXwgh6n1dJpNhxowZmDFjRvMVRUTUQBYBePV9Gm9vzwcAtA5ww6dPdUWMv5vElRG1LHbbAZiIyJ4VlFVia5YLPLs/DKC6f8y0IR2gVbF/DFFzY5ghIroBZovA4bRCJJ7Pg8kih9lQhGkDIvHcsE5Sl0bUYtntaCYiIntzsbAcK/bqseNcLkwWAX+1BZmLX8QdrTRSl0bUorFlhojoOgyVJvx5LhcnM6tvcqtRynFnaz94lKZjX2m+xNUREcMMEVE9KkxmHNAX4pC+EJVmCwAgLsQDvVr7QatUIP1susQVEhHAMENEVEulyYLD6YXYn1qAClN1iAlwV6NvW38Ee2olro6IrsYwQ0R0maHShKMXi3A4rQjlVWYAgI+rCj2ifdDa340T4BHZKYYZImrxcksrcFBfiNPZJTBbque+8tQq0SPaB20C3SFniCGyawwzRNQiVZosOHepFCczipFeWG5dHuCuRpdwL8QGuEMhZ4ghcgQMM0TUYgghcLGwHCcyi3EupxRV5upWGBmAmAA3dAnzQrCnhpeTiBwMwwwROTWLRSC9sBznckqRfKkUhkqz9TVPrRIdgj3QLtgdHhqlhFUS0c1gmCEip2OoNCEtvxyp+WVIuVQG4+URSQCgUsgRG+iGDsEebIUhchIMM0Tk8CwCSC8wIDXPAH2+ATklFTava5UKRPu7orW/G8J8dOwLQ+RkGGaIyOEYq8w4nFaIn06UIuCRGfg5XQlT2kWbdfzcVIjwcUWErw6tvLSQM8AQOS2GGSKye3mXh04npeZj34UCHE0vss7Iq41JgElUt76E++oQ4aNDuI8Ormr+eCNqKfivnYjsSlmFCccuFuFweiEOpxfhcFoh0gvKa63n765GrKcM6776CH8bNQ4dO7Rm/xeiFophhugm6PV65ObmSlqDn58fwsPDJa2hsarMFpzOKsGhtEIcSS/E4bQinM0pweV562xE+7uiW4QPukX5oFukN8J9dDh48CBWvPgzvMY9zSBD1IIxzBA1kl6vR7v27VFuMEhah1anw6mTJ+0+0AghcCHPgMNphdbwcjyj2HrvoysFe2rQOdQT8WFeiA/1QqdQTw6dJqJ6McwQNVJubi7KDQaMfG0uAsNjJKkhW5+Mb95/Bbm5uXYXZnJKjDicVoQj6TXhpQhF5VW11vPQuFhDS02ACfTQSFAxETkqhhmimxQYHoPQ2I5SlyGp0goTjqZf7ueSVv3IKDLWWk/lIkdciAc6h3rhtrDq8BLl58pLRER0UxhmiOiGVJou93O5Iricu1QKcVU/F5kMiA1wQ3yoF+LDqsNLm0B3qFzk0hRORE6LYYaI6mWxCFzIK7vc4lLd8nI8oxiVdfRzaeWlRXyYpzW8xLXyhBuHRxNRM+BPGiKyyik2WodD11wyKjaaaq3nqVVWt7aEeqJzqBc6h3kiwJ39XIhIGgwzRC1UibEKRy8WVbe4XA4vmXX0c1G7yNExxMN6qSg+1AsRvjr2cyEiu8EwQ9QCVJosOJVVfDm0FF2zn0ubAPfqy0WXg0vbIHcoFeznQkT2i2GGyMlc3c/lUFohTmQUW6f/v1IrL211a8vlvi5xrTxv+DYAUk4cePLkSUn2ezWp6rCX4yeSGsMMkYNTuHpj70Ujfr90ytpJt6SOfi5eOmV159zLc7l0DvWCv7v6pvZtLxMHlpaWSrLf4vxLAIBRo0ZJsv8aUh0/kb1gmCFyIBUmM3KKK5BVbER2sREZ+UqEvvA1Zu8sAFBgXU/tIkdcq5qRRZ64LcwL4T5N389F6okDT+7djl+XfASjsXZfn+ZQXloMABj67DS07dy12fcv9fET2QuGGSI7ZbJYkFtaiezLwSW7qAL5hsqr1pJBWMyI9FajR2xwdT+XME+0CWzefi5STRyYrU9u9n3WxTckokUfP5HUGGaI7ERZhQmZRUZkFpUjs8iInOIKmK/uoYvq6f8DPTQI8tBAVpyJZa8/gdW7d+L22ztLUDURkfQYZogkIIRAgaEKaQUGZBZWB5i65nPRKOUI9NBYw0ughxo61V//bNPPZkBU8RIDEbVsDDNEzaTYWIW0fAPSCsqRnm9AWaXZ5nUZAF83FYI9tQj21CDYUwNPrZLzuRARXQfDDNEtYjJbkF5QjvO5ZUjLN6DwqjtGK+QyhHhq0MpLi2AvLQI91FC7KCSqlojIcTHMEDWh8iozUi6V4XxuKfT5BlSZ/+rzIpMBge4ahPloEeatQ7CnBi5N1EmX85wQUUvGMEN0k6oswInMYpzJLkFavgGWK/rsuqldEOXnikhfHVp5a5u85YXznBARMcwQNUqV2YK9F43wf+hNrEtXwoJs62v+bmpE+7si2t8V/m7qW9rnhfOcEBExzBDdkORLpVi5Lw2rDlzEpZIK6Nr2ggWAj06FNkFuaBPoDm+dqtnr4jwnRNSSMcwQXYfJbMGmE9n4atcF7EnJty73UMuRtuMHPPzAMHTo0JqjjoiIJMIwQ1SP/LJKfJukx7LEVGQUVV9GkcuAvm0D8GhCGHyMF9H9nf/B85H7GWSIiCTEMEN0lfQCAz7/4zy+TUpDhan6TtM+rio8cUcYRnaPQIiXFgBw4ECGlGUSEdFlDDNEl53LKcWi7clYc/AiTJeHJHUM8cDYXpEYFh8CjZJzwBAR2SOGGXJoer0eubm5N7WN5IIqrDpZit3pRtSMqu4coMLD7d0QF6CCTHYJJ45eqvU+zrFCRGQfGGbIYen1erRr3x7lBkOj3q8MiIZ3n9HQRidYlxnOJKJo9/dIzTyDnxu4Hc6xQkQkLYYZcli5ubkoNxgw8rW5CAyPafD7SquAE0UKpBmqLxvJIBCms6CNhwWe4V2Bexs2XwvnWCEisg8MM+TwAsNjGjTHSlmFCUkX8nE0q8g6S2/bQHf0iPaBVyPmhuEcK0RE9oFhhpxepcmCA/oCHNAXWO+VFOGjQ6/Wvghw10hcHRER3SyGGXJaZovA0YtF2JuSj/IqMwAg0EON3jF+CPPRSVwdERE1FYYZcjpCCJzOLsHu8/koKq8CAHhplegV44vWAW6c4I6IyMkwzJDTEEJAn2/AznN5uFRaAQDQqRToEeWLDiEeUMgZYoiInBHDDDmFrGIjdp7LRXpBOQBApZCja4Q3uoR7QamQS1wdERHdSgwz5NBcvEOwO1eBi/o0AIBCJkPnUE90i/SBVsUZe4mIWgKGGXJIOcVGfLq/CCHPLMTFy/PFtA9yR49oX3holRJXR0REzYlhhhxKibEKn/1xHl/sSEF5lRkyuQJBGgvuiY+En5ta6vKIiEgC7ExADsFYZcYXO87j7jlb8d8t51BeZUYbXyWyvnkNvQNMDDJERC0YW2bIrlWZLfh+Xzr+8/tZZBVX3zYgxt8VrwxqB/+Ki0h49bjEFRIRkdQYZsguWSwCPx/JwLxNZ5CaV30jyRBPDSbdG4uHbw+Fi0KOAwcyJK6SiIjsAcMM2RUhBDadyMYHG8/gdHYJAMDPTYWJ/Vrjye7hULtwhBIREdlimCG7YLYI/HosE59sTcbJzGIAgLvGBc/1icHYXpFwVfOrSkREdeNvCJJUldmCNQcvYuH2ZJy/VAYAcFUpMLpXJJ67OwaeOg6zJiKia2OYIUkYq8xYuS8Nn24/j4uF1bP2emqVGNsrEk/3joSXTiVxhURE5CgYZqhZ5ZQY8c1uPb7Zk4rc0koAgJ+bGv93VxRG9oiAGy8nERHRDeJvDmoWh9MK8dWuC1h3JANVZgEAaOWlxbN9ovFoQhg0SnbsJSKixmGYoVum2FiFtYcysHJfGo6kF1mXd43wxthekbgvLog3gSQiopvGMENNymIR2HshHyv3peGXo5kwVlkAAEqFDPd3DsHYXpGID/OStkgiInIqDDN004QQOJRWiHVHMrH+SKZ1pl4AiA1ww2PdwjC8Syv48pYDRER0CzDMUKNUmixIupCPLady8NvxLKQXlFtfc1e7YEinYDzaLQy3h3tBJpNJWCkRETk7hpmbpNfrkZubK9n+/fz8EB4efsv3I4TAhTwDdp/Pw7bTOfjzbC7KKs3W1zUuMnQLUaN3mBa3BamhUpiAvBQczLt1NZ08efLWbZyIiBwGw8xN0Ov1aNe+PcoNBslq0Op0OHXyZJMHmkqTBWeyS3AwrRB7zudhb0o+ckoqbNbx0brg4v5NKDm9C8bzB3DaVIFlTVpFw5SWlkqwVyIishcMMzchNzcX5QYDRr42F4HhMc2+/2x9Mr55/xXk5uY2OswIIZBTUoHkS6VIvlSGExlFOHaxGKezSlBpttisq1LIER/mid6t/dC/XQAqs5PRbcYHl4//laY4pBtycu92/LrkIxiNxuuvTERETothpgkEhscgNLaj1GXUYrEIFBurUGCoQn5ZJbKLjcgoLEdWkRGZRUbo8w1IyS1DaYWpzvd7aFzQKdQTd0T64o4oH3QJ97KZD+ZATnVfGKmOP1uf3Oz7JCIi++MQYWbBggWYO3cuMjMz0bFjR8yfPx933XWXpDX9uD8di37PRdBT/w9bs1ygKkyrd12ZDJABgAyQQWZ9XtMxttZz6zLZ5ffU/bysSAG/B1/Hezvyod63G+VVZhirzCivMqPEaEKhoRIWcf1jkcuAMB8dov1c0S7YA51aeSIuxBNhPlp23iUiIrtn92Hmu+++w+TJk7FgwQL07t0bn376KQYPHowTJ040S8fX+mSXGHE2vwrqkHbIrwRQKcWlDgVc292JA5kVACrqXctVpYC3qwqBHhoEe9Y8tAjx0iLG3xXhvjqoXTgDLxEROSa7DzPz5s3D+PHj8cwzzwAA5s+fj99++w0LFy7ErFmzJKtrcFwwFKU5mDJ5Ch587g34hfwVrK5uDBECEBC4/N9fz63/X9135crnuLyO9fnldWreDwCFuVnYvvJz/Gva62jXOhoapQJapQJalRyuahf46FTw1CkZVIiIyKnZdZiprKzE/v378frrr9ssHzhwIHbt2iVRVdWi/FzRLUSD8uS9CNEJhPq7NXsN6ZUZWH9wPe6Jege3x4c0+/6JiIjsgV2HmdzcXJjNZgQGBtosDwwMRFZWVp3vqaioQEXFX5dcioqq7wlUXFzc5PXVDAlOP3scFeXNPzz7UnoKAGD//v2SDE8+ffo0AOmOv6YDcNaFM0h21bW4/dtDDdx/y96/PdTA/Uu7/5rfQ6WlpU3+e7ZmezVXLq5J2LGLFy8KAGLXrl02y9977z3Rtm3bOt8zffp0gctXbvjggw8++OCDD8d+pKWlXTcv2HXLjJ+fHxQKRa1WmJycnFqtNTXeeOMNvPTSS9bnFosF+fn58PX1lXRkTnFxMcLCwpCWlgYPDw/J6pBCSz32lnrcAI+dx85jbylu5XELIVBSUoKQkOt3o7DrMKNSqdC1a1ds2rQJw4cPty7ftGkTHnzwwTrfo1aroVbb3tDQy8vrVpZ5Qzw8PFrUF/1KLfXYW+pxAzx2HnvL01KP/VYdt6enZ4PWs+swAwAvvfQSnnrqKSQkJKBnz5747LPPoNfr8dxzz0ldGhEREdkBuw8zjz32GPLy8vDOO+8gMzMTcXFx+OWXXxARESF1aURERGQH7D7MAMCECRMwYcIEqcu4KWq1GtOnT691CawlaKnH3lKPG+Cx89h57C2FvRy3TIiGjHkiIiIisk9yqQsgIiIiuhkMM0REROTQGGaIiIjIoTHMEBERkUNjmGliFy9exKhRo+Dr6wudTofbbrsN+/fvt74+duxYyGQym0ePHj0krLhpREZG1joumUyGiRMnAqieyXHGjBkICQmBVqtF3759cfz4cYmrbhrXO3ZnPecmkwn//Oc/ERUVBa1Wi+joaLzzzjuwWCzWdZz1vDfk2J31vANASUkJJk+ejIiICGi1WvTq1QtJSUnW1531vAPXP3ZnOe9//PEHhg0bhpCQEMhkMqxZs8bm9Yac44qKCrz44ovw8/ODq6srHnjgAaSnp9+agm/u7kl0pfz8fBERESHGjh0r9uzZI1JSUsTmzZvFuXPnrOuMGTNG3HfffSIzM9P6yMvLk7DqppGTk2NzTJs2bRIAxNatW4UQQsyePVu4u7uLH3/8URw9elQ89thjIjg4WBQXF0tbeBO43rE76zl/7733hK+vr1i3bp1ISUkR33//vXBzcxPz58+3ruOs570hx+6s510IIR599FHRoUMHsX37dnH27Fkxffp04eHhIdLT04UQznvehbj+sTvLef/ll1/EtGnTxI8//igAiNWrV9u83pBz/Nxzz4lWrVqJTZs2iQMHDoh+/fqJ+Ph4YTKZmrxehpkm9Nprr4k777zzmuuMGTNGPPjgg81TkIQmTZokYmJihMViERaLRQQFBYnZs2dbXzcajcLT01MsWrRIwipvjSuPXQjnPedDhw4V48aNs1k2YsQIMWrUKCGEcOrzfr1jF8J5z7vBYBAKhUKsW7fOZnl8fLyYNm2aU5/36x27EM553q8OMw05x4WFhUKpVIpvv/3Wus7FixeFXC4XGzZsaPIaeZmpCa1duxYJCQn429/+hoCAAHTp0gWff/55rfW2bduGgIAAtGnTBv/3f/+HnJwcCaq9dSorK7Fs2TKMGzcOMpkMKSkpyMrKwsCBA63rqNVq9OnTB7t27ZKw0qZ39bHXcMZzfuedd+L333/HmTNnAACHDx/Gn3/+iSFDhgCAU5/36x17DWc87yaTCWazGRqNxma5VqvFn3/+6dTn/XrHXsMZz/uVGnKO9+/fj6qqKpt1QkJCEBcXd0u+Bw4xA7CjOH/+PBYuXIiXXnoJb775Jvbu3Yt//OMfUKvVGD16NABg8ODB+Nvf/oaIiAikpKTgrbfeQv/+/bF//37JZ1BsKmvWrEFhYSHGjh0LANa7nl99p/PAwECkpqY2d3m31NXHDjjvOX/ttddQVFSEdu3aQaFQwGw249///jeeeOIJAM593q937IDznnd3d3f07NkT7777Ltq3b4/AwECsWLECe/bsQWxsrFOf9+sdO+C85/1KDTnHWVlZUKlU8Pb2rrVOzfubEsNME7JYLEhISMDMmTMBAF26dMHx48excOFCa5h57LHHrOvHxcUhISEBERERWL9+PUaMGCFJ3U3tyy+/xODBg2vdtv3KlgqgugPZ1cscXV3H7qzn/LvvvsOyZcuwfPlydOzYEYcOHcLkyZMREhKCMWPGWNdzxvPekGN31vMOAF9//TXGjRuHVq1aQaFQ4Pbbb8eTTz6JAwcOWNdxxvMOXP/Ynfm8X60x5/hWfQ94makJBQcHo0OHDjbL2rdvD71ef833RERE4OzZs7e6vGaRmpqKzZs345lnnrEuCwoKAoBaaTwnJ6dWsndkdR17XZzlnL/yyit4/fXX8fjjj6NTp0546qmnMGXKFMyaNQuAc5/36x17XZzlvANATEwMtm/fjtLSUqSlpWHv3r2oqqpCVFSUU5934NrHXhdnOu81GnKOg4KCUFlZiYKCgnrXaUoMM02od+/eOH36tM2yM2fOXPMO33l5eUhLS0NwcPCtLq9ZLF68GAEBARg6dKh1Wc0PuE2bNlmXVVZWYvv27ejVq5cUZd4SdR17XZzlnBsMBsjltj9CFAqFdXiyM5/36x17XZzlvF/J1dUVwcHBKCgowG+//YYHH3zQqc/7leo69ro443lvyDnu2rUrlEqlzTqZmZk4duzYrfkeNHmX4hZs7969wsXFRfz73/8WZ8+eFd98843Q6XRi2bJlQgghSkpKxMsvvyx27dolUlJSxNatW0XPnj1Fq1atnGLIotlsFuHh4eK1116r9drs2bOFp6enWLVqlTh69Kh44oknnGaophD1H7szn/MxY8aIVq1aWYcnr1q1Svj5+YlXX33Vuo6znvfrHbszn3chhNiwYYP49ddfxfnz58XGjRtFfHy8uOOOO0RlZaUQwnnPuxDXPnZnOu8lJSXi4MGD4uDBgwKAmDdvnjh48KBITU0VQjTsHD/33HMiNDRUbN68WRw4cED079+fQ7Mdxc8//yzi4uKEWq0W7dq1E5999pn1NYPBIAYOHCj8/f2FUqkU4eHhYsyYMUKv10tYcdP57bffBABx+vTpWq9ZLBYxffp0ERQUJNRqtbj77rvF0aNHJajy1qjv2J35nBcXF4tJkyaJ8PBwodFoRHR0tJg2bZqoqKiwruOs5/16x+7M510IIb777jsRHR0tVCqVCAoKEhMnThSFhYXW1531vAtx7WN3pvO+detWAaDWY8yYMUKIhp3j8vJy8cILLwgfHx+h1WrF/ffff8s+C5kQQjR9ew8RERFR82CfGSIiInJoDDNERETk0BhmiIiIyKExzBAREZFDY5ghIiIih8YwQ0RERA6NYYaIiIgcGsMMEREROTSGGSK6prFjx+Khhx5qln1FRkZi/vz5zbIve3P69GkEBQWhpKSk0ds4evQoQkNDUVZW1oSVEdk/hhkiB5KVlYVJkyahdevW0Gg0CAwMxJ133olFixbBYDBIXV6DffXVV/Dy8qq1PCkpCX//+99v6b63bdsGmUxmffj6+qJ///7YuXNno7ZTWFjYJHVNmzYNEydOhLu7OwDgwoULuPvuu+Hm5oY+ffogNTXVZv2hQ4fixx9/tFnWqVMn3HHHHfjwww+bpCYiR8EwQ+Qgzp8/jy5dumDjxo2YOXMmDh48iM2bN2PKlCn4+eefsXnz5nrfW1VV1YyVNp6/vz90Ol2z7Ov06dPIzMzEtm3b4O/vj6FDhyInJ6dZ9n219PR0rF27Fk8//bR12csvv4xWrVrh4MGDCAoKwtSpU62vffvtt1AoFHj44Ydrbevpp5/GwoULYTabm6V2IrtwS+74RERNbtCgQSI0NFSUlpbW+brFYrH+PwCxcOFC8cADDwidTif+9a9/CZPJJMaNGyciIyOFRqMRbdq0EfPnz7fZhslkElOmTBGenp7Cx8dHvPLKK2L06NHiwQcftK4TEREhPvzwQ5v3xcfHi+nTp1uff/DBByIuLk7odDoRGhoqnn/+eVFSUiKEqPsGdjXvvXrbqamp4oEHHhCurq7C3d1d/O1vfxNZWVnW16dPny7i4+PF0qVLRUREhPDw8BCPPfbYNe9QXLP/goIC67IjR44IAGLt2rXWZV9//bXo2rWrcHNzE4GBgeKJJ54Q2dnZQgghUlJSrnkDvvfff19ERUUJjUYjOnfuLL7//vt666n5vBISEmyWtW/fXvz6669CCCF++eUX0aFDByGEEAUFBSImJsZ69+KrVVRUCLVaLX7//fdr7pPImbBlhsgB5OXlYePGjZg4cSJcXV3rXEcmk9k8nz59Oh588EEcPXoU48aNg8ViQWhoKFauXIkTJ07gX//6F958802sXLnS+p4PPvgA//vf//Dll1/izz//RH5+PlavXn3D9crlcvznP//BsWPHsGTJEmzZsgWvvvoqAKBXr16YP38+PDw8kJmZiczMTJtWhxpCCDz00EPIz8/H9u3bsWnTJiQnJ+Oxxx6zWS85ORlr1qzBunXrsG7dOmzfvh2zZ89ucK0GgwGLFy8GACiVSuvyyspKvPvuuzh8+DDWrFmDlJQUjB07FgAQFhZmvcRT08Lz0UcfAQD++c9/YvHixVi4cCGOHz+OKVOmYNSoUdi+fXu9Nfzxxx9ISEiwWRYfH4/NmzfDYrFg48aN6Ny5MwBg6tSpeOGFFxAeHl7ntlQqFeLj47Fjx44GfwZEDk/qNEVE17d7924BQKxatcpmua+vr3B1dRWurq7i1VdftS4HICZPnnzd7U6YMEE8/PDD1ufBwcFi9uzZ1udVVVUiNDT0hltmrrZy5Urh6+trfb548WLh6elZa70rt71x40ahUCiEXq+3vn78+HEBQOzdu1cIUd0yo9PpbFpiXnnlFdG9e/d6a6lpman53GQymQAgunbtKiorK+t93969ewWAWi1MV7bwlJaWCo1GI3bt2mXz3vHjx4snnnii3m3Hx8eLd955x2ZZenq6GDp0qAgLCxNDhw4V6enpYvv27SIhIUHk5eWJv/3tbyIqKko8++yzoqKiwua9w4cPF2PHjq13f0TOxkXCHEVEN+jq1pe9e/fCYrFg5MiRqKiosHnt6r/0AWDRokX44osvkJqaivLyclRWVuK2224DABQVFSEzMxM9e/a0ru/i4oKEhAQIIW6ozq1bt2LmzJk4ceIEiouLYTKZYDQaUVZWVm/L0tVOnjyJsLAwhIWFWZd16NABXl5eOHnyJLp16wagegRUTadZAAgODm5Q35cdO3bA1dUVBw8exGuvvYavvvrKpmXm4MGDmDFjBg4dOoT8/HxYLBYAgF6vR4cOHerc5okTJ2A0GjFgwACb5ZWVlejSpUu9tZSXl0Oj0dgsa9WqFdatW2d9XlFRgUGDBmHp0qV477334O7ujtOnT+O+++7Dp59+ihdffNG6rlardagO4UQ3i2GGyAG0bt0aMpkMp06dslkeHR0NoPqX19WuDg0rV67ElClT8MEHH6Bnz55wd3fH3LlzsWfPnhuqRS6X1wo3V3YwTk1NxZAhQ/Dcc8/h3XffhY+PD/7880+MHz/+hjoiCyFqhbe6ll8ZQIDqwFcTPK4lKioKXl5eaNOmDYxGI4YPH45jx45BrVajrKwMAwcOxMCBA7Fs2TL4+/tDr9dj0KBBqKysrHebNftdv349WrVqZfOaWq2u931+fn4oKCi4Zr3//ve/MXDgQNx+++145pln8N5770GpVGLEiBHYsmWLTZjJz89HTEzMdT8DImfBPjNEDsDX1xcDBgzAxx9/3Og5RHbs2IFevXphwoQJ6NKlC1q3bo3k5GTr656enggODsbu3buty0wmE/bv32+zHX9/f2RmZlqfFxcXIyUlxfp83759MJlM+OCDD9CjRw+0adMGGRkZNttQqVTXHW3ToUMH6PV6pKWlWZedOHECRUVFaN++/Y0d/HU89dRTsFgsWLBgAQDg1KlTyM3NxezZs3HXXXehXbt2tVp7VCoVANgcR4cOHaBWq6HX69G6dWubx5UtTFfr0qULTpw4Ue/rJ0+exIoVK/DOO+9Y91kTDKuqqmp9lseOHbtmSxCRs2GYIXIQCxYsgMlkQkJCAr777jucPHkSp0+fxrJly3Dq1CkoFIprvr9169bYt28ffvvtN5w5cwZvvfUWkpKSbNaZNGkSZs+ejdWrV+PUqVOYMGFCrXlU+vfvj6+//ho7duzAsWPHMGbMGJt9x8TEwGQy4b///S/Onz+Pr7/+GosWLbLZRmRkJEpLS/H7778jNze3zksi9957Lzp37oyRI0fiwIED2Lt3L0aPHo0+ffrUeQntZsjlckyePBmzZ8+GwWBAeHg4VCqV9RjWrl2Ld9991+Y9ERERkMlkWLduHS5duoTS0lK4u7tj6tSpmDJlCpYsWYLk5GQcPHgQn3zyCZYsWVLv/gcNGoTExMQ6A54QAn//+9/x4Ycfws3NDQDQu3dvfP755zh58iSWLl2K3r17W9e/cOECLl68iHvvvbeJPh0iByBpjx0iuiEZGRnihRdeEFFRUUKpVAo3Nzdxxx13iLlz54qysjLregDE6tWrbd5rNBrF2LFjhaenp/Dy8hLPP/+8eP3110V8fLx1naqqKjFp0iTh4eEhvLy8xEsvvVRraHZRUZF49NFHhYeHhwgLCxNfffVVrQ7A8+bNE8HBwUKr1YpBgwaJpUuX1uos+9xzzwlfX98mGZp9pQ8//FBERETU+xnW1XFXiOrOu97e3uL9998XQgixfPlyERkZKdRqtejZs6dYu3atACAOHjxofc8777wjgoKChEwmsxma/dFHH4m2bdsKpVIp/P39xaBBg8T27dvrrclkMolWrVqJDRs21Hpt0aJFNp20hRAiOztb3HPPPdbP5MpzP3PmTDFo0KB690XkjGRC3GDPPiIianILFizATz/9hN9++63R26ioqEBsbCxWrFhh01pD5OzYAZiIyA78/e9/R0FBAUpKSmxGZ92I1NRUTJs2jUGGWhy2zBAREZFDYwdgIiIicmgMM0REROTQGGaIiIjIoTHMEBERkUNjmCEiIiKHxjBDREREDo1hhoiIiBwawwwRERE5NIYZIiIicmj/H6b1ERtVT3FcAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjMAAAHFCAYAAAAHcXhbAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZWRJREFUeJzt3Xd8U+X+B/BPkmY0bdrSvQel7A2KDGUJCAgIoqigLK8D9TJEEbkKLqYiXr2A+lNAERQVEMEByBaUvUtZpYPuvdMmeX5/lEZCB6VNe5L2837dvLw5OTnn2yen6YfnPM85MiGEABEREZGdkktdABEREVFtMMwQERGRXWOYISIiIrvGMENERER2jWGGiIiI7BrDDBEREdk1hhkiIiKyawwzREREZNcYZoiIiMiuMcwQAGD16tWQyWTmh0ajga+vL/r27YsFCxYgJSWl3HvmzZsHmUx2R/spKCjAvHnzsGfPnjt6X0X7Cg0NxYMPPnhH27mddevWYdmyZRW+JpPJMG/ePKvuz9r++OMPdO3aFU5OTpDJZNi8eXOV6ycnJ+P1119Hx44d4eLiApVKhcDAQIwaNQpbtmyB0Wisl7r37NkDmUx2x8fFnZo/f36FbVJf+6/IhAkTLH73VCoVwsPDMXPmTOTk5NRomwkJCZg3bx5Onjxp3WJhvd+Da9euWfzcVT2uXbtW6/3VpE0iIyPx5JNPomnTptBoNPD09ETnzp3x4osv1uizOXjwIObNm4esrKw7fi9VzUHqAsi2rFq1Ci1btkRJSQlSUlJw4MABLFq0CO+//z6+++473H///eZ1n376aTzwwAN3tP2CggK89dZbAIA+ffpU+3012VdNrFu3DmfPnsW0adPKvXbo0CEEBgbWeQ01JYTAo48+iubNm2PLli1wcnJCixYtKl3/r7/+wvDhwyGEwPPPP4977rkHzs7OiI2Nxc8//4xRo0bh008/xeTJk+vxp6hb8+fPx+jRo/HQQw9ZLO/cuTMOHTqE1q1bS1KXo6Mjdu3aBQDIysrCDz/8gA8++ACnT5/G9u3b73h7CQkJeOuttxAaGoqOHTtatVZr/R74+fnh0KFDFsumTJmC7OxsfPPNN+XWra07bZMTJ06gZ8+eaNWqFd58802EhoYiLS0Np06dwrfffouZM2fCxcXljmo4ePAg3nrrLUyYMAFubm41+0GoQgwzZKFt27bo2rWr+fnDDz+M6dOno1evXhg1ahQuXboEHx8fAEBgYGCd/3EvKCiAVqutl33dzj333CPp/m8nISEBGRkZGDlyJPr371/lullZWXjooYfg7OyMP//8s9wfi3HjxuH06dNIT0+vcjuFhYXQaDR33ENna1xcXCT9fOVyucX+H3jgAVy9ehU7duxAdHQ0wsLCJKvtVtZqJ7VaXW5bLi4uKC4utonftWXLlkEul2PPnj3Q6XTm5aNHj8Y777wD3tbQtvA0E91WcHAwPvjgA+Tm5uLTTz81L6/o1M+uXbvQp08feHh4wNHREcHBwXj44YdRUFCAa9euwcvLCwDw1ltvmbuQJ0yYYLG948ePY/To0WjSpAnCw8Mr3VeZTZs2oX379tBoNGjatCn++9//Wrxedgrt1q7qW08t9OnTB9u2bUNMTIxFF3eZirrXz549ixEjRqBJkybQaDTo2LEj1qxZU+F+1q9fjzlz5sDf3x8uLi64//77ERUVVXnD3+TAgQPo378/dDodtFotevTogW3btplfnzdvnjnszZo1CzKZDKGhoZVu7/PPP0dycjIWL15c6b9627dvj759+5qfl7Xj9u3bMWnSJHh5eUGr1UKv1+Py5cuYOHEiIiIioNVqERAQgGHDhuHMmTPltnvhwgU88MAD0Gq18PT0xHPPPYfc3Nxy64WGhpqPjZv16dPHolevqKgIL7/8Mjp27AhXV1e4u7uje/fu+OmnnyzeJ5PJkJ+fjzVr1pg/27LtVHaaacuWLejevTu0Wi10Oh0GDBhQrjeh7Ng8d+4cHn/8cbi6usLHxweTJk1CdnZ2hW1bHWX/qEhOTjYvq04779mzB3fddRcAYOLEieaf9eZj9+jRoxg+fDjc3d2h0WjQqVMnbNiwoVp13bqtsuNi9+7deP755+Hp6QkPDw+MGjUKCQkJNf75y+Tk5GDmzJkICwuDSqVCQEAApk2bhvz8fIv1vv/+e3Tr1g2urq7QarVo2rQpJk2aBKB6bXKr9PR0uLi4wNnZucLXb/0+2rlzJ/r37w8XFxdotVr07NkTf/zxh/n1efPm4ZVXXgEAhIWFmWuQ4tRmQ8QwQ9UyZMgQKBQK7Nu3r9J1rl27hqFDh0KlUuHLL7/Eb7/9hoULF8LJyQnFxcXw8/PDb7/9BgCYPHkyDh06hEOHDuGNN96w2M6oUaPQrFkzfP/991i5cmWVdZ08eRLTpk3D9OnTsWnTJvTo0QNTp07F+++/f8c/4/Lly9GzZ0/4+vqaa7v1D9fNoqKi0KNHD5w7dw7//e9/sXHjRrRu3RoTJkzA4sWLy63/+uuvIyYmBv/3f/+Hzz77DJcuXcKwYcNuOy5l79696NevH7Kzs/HFF19g/fr10Ol0GDZsGL777jsApafhNm7cCAB46aWXcOjQIWzatKnSbe7YsQMKhQJDhgypTtNYmDRpEpRKJb7++mv88MMPUCqVSEhIgIeHBxYuXIjffvsN//vf/+Dg4IBu3bpZBLbk5GT07t0bZ8+exfLly/H1118jLy8PL7744h3XUUav1yMjIwMzZ87E5s2bsX79enNP4ldffWVe79ChQ3B0dMSQIUPMn+3y5csr3e66deswYsQIuLi4YP369fjiiy+QmZmJPn364MCBA+XWf/jhh9G8eXP8+OOPeO2117Bu3TpMnz69xj9XdHQ0HBwc0LRpU/Oy6rRz586dsWrVKgDAf/7zH/PP+vTTTwMAdu/ejZ49eyIrKwsrV67ETz/9hI4dO2LMmDFYvXp1jet9+umnoVQqsW7dOixevBh79uzBuHHjarw9oLRntnfv3lizZg3+/e9/49dff8WsWbOwevVq8ylSoPSzHTNmDJo2bYpvv/0W27Ztw5tvvgmDwVCtNqlI9+7dkZiYiLFjx2Lv3r0oLCysdN21a9di4MCBcHFxwZo1a7Bhwwa4u7tj0KBB5kDz9NNP46WXXgIAbNy40VxD586da9VGdIMgEkKsWrVKABBHjhypdB0fHx/RqlUr8/O5c+eKmw+hH374QQAQJ0+erHQbqampAoCYO3duudfKtvfmm29W+trNQkJChEwmK7e/AQMGCBcXF5Gfn2/xs0VHR1ust3v3bgFA7N6927xs6NChIiQkpMLab637scceE2q1WsTGxlqsN3jwYKHVakVWVpbFfoYMGWKx3oYNGwQAcejQoQr3V+aee+4R3t7eIjc317zMYDCItm3bisDAQGEymYQQQkRHRwsAYsmSJVVuTwghWrZsKXx9fcstNxqNoqSkxPwwGo3m18ra8amnnrrt9g0GgyguLhYRERFi+vTp5uWzZs2q9DO79bMICQkR48ePL7ft3r17i969e1e575KSEjF58mTRqVMni9ecnJwq3Oatx4LRaBT+/v6iXbt2Fm2Qm5srvL29RY8ePczLyo7NxYsXW2xzypQpQqPRmD+fyowfP144OTmZ2zwtLU2sWLFCyOVy8frrr1f53sra+ciRIwKAWLVqVbn3tGzZUnTq1EmUlJRYLH/wwQeFn5+fxc9bkVt/D8qOiylTplist3jxYgFAJCYmVrm9m/Xu3Vu0adPG/HzBggVCLpeX+14q+6755ZdfhBBCvP/++wKA+XeuIlW1SUWKiorEQw89JAAIAEKhUIhOnTqJOXPmiJSUFPN6+fn5wt3dXQwbNszi/UajUXTo0EHcfffd5mVLliyp8LuIao89M1Rt4jbniDt27AiVSoVnnnkGa9aswdWrV2u0n4cffrja67Zp0wYdOnSwWPbEE08gJycHx48fr9H+q2vXrl3o378/goKCLJZPmDABBQUF5Xp1hg8fbvG8ffv2AICYmJhK95Gfn4+///4bo0ePtujuVigUePLJJxEfH1/tU1XVMWPGDCiVSvPj1pqBij8fg8GA+fPno3Xr1lCpVHBwcIBKpcKlS5cQGRlpXm/37t2Vfma18f3336Nnz55wdnaGg4MDlEolvvjiC4t934moqCgkJCTgySefhFz+z9eks7MzHn74Yfz1118oKCiweE9Fn29RUVGFMwFvlZ+fb25zT09PPP/88xgzZgzee+89i/Wq286VuXz5Mi5cuICxY8eat1f2GDJkCBITE2t8PNXk+L6drVu3om3btujYsaNFrYMGDbI4RVN2CunRRx/Fhg0bcP369Rrvs4xarcamTZtw/vx5fPjhh3jssceQmpqK9957D61atTK308GDB5GRkYHx48db1GgymfDAAw/gyJEj5U6JkfUxzFC15OfnIz09Hf7+/pWuEx4ejp07d8Lb2xsvvPACwsPDER4ejo8++uiO9nUnMxd8fX0rXXa7wau1lZ6eXmGtZW106/49PDwsnqvVagCosvs6MzMTQog72k91BAcHIzU1tdwf5JdffhlHjhzBkSNHKv0cKlo+Y8YMvPHGG3jooYfw888/4++//8aRI0fQoUMHi58vPT29ys+sJjZu3IhHH30UAQEBWLt2LQ4dOoQjR45g0qRJKCoqqtE2y9q0snY3mUzIzMy0WF6Tz7eMo6Ojud1//vln9OnTB+vXr8fChQst1qtuO1embPzNzJkzLUKrUqnElClTAABpaWm33U5FavPzV1Xv6dOny9Wq0+kghDDXet9992Hz5s0wGAx46qmnEBgYiLZt22L9+vU13neZVq1aYdq0aVi7di1iY2OxdOlSpKenm0+Pl7Xp6NGjy9W5aNEiCCGQkZFR6zqoapzNRNWybds2GI3G206nvvfee3HvvffCaDTi6NGj+PjjjzFt2jT4+Pjgscceq9a+7mRmTFJSUqXLyr5cNRoNgNKxFTer6Zd2GQ8PDyQmJpZbXjbo0dPTs1bbB4AmTZpALpdbfT8DBgzA9u3b8csvv2D06NHm5UFBQeaeJpVKVeF7K/p81q5di6eeegrz58+3WJ6WlmYxBdXDw6PKz+xmGo2m3GdWts2bf+a1a9ciLCwM3333nUVtFb23usqOncraXS6Xo0mTJjXe/q3kcrnFLMIBAwagS5cueOuttzB27FjzZ1Lddq5MWbvNnj0bo0aNqnCdqqbz1zdPT084Ojriyy+/rPT1MiNGjMCIESOg1+vx119/YcGCBXjiiScQGhqK7t27W6UemUyG6dOn4+2338bZs2ctavj4448rnYVVNgOU6g57Zui2YmNjMXPmTLi6uuLZZ5+t1nsUCgW6deuG//3vfwBgPuVjjX+t3ezcuXM4deqUxbJ169ZBp9OZB9aVzeo5ffq0xXpbtmwptz21Wl3t2vr3749du3aVm7Hx1VdfQavVWmV6qZOTE7p164aNGzda1GUymbB27VoEBgaiefPmd7zdp59+Gj4+Pnj11Vcr/IN9p2QymfmzLbNt27Zy3f19+/at9DO7VWhoaLnP7OLFi+VOg5RdaO7mIJOUlFRuNhNQ/c+3RYsWCAgIwLp16yxOr+bn5+PHH380z3CqK2q1Gv/73/9QVFSEd99917y8uu1c2e9ZixYtEBERgVOnTqFr164VPm6ehiy1Bx98EFeuXIGHh0eFtVY0Y0+tVqN3795YtGgRgNLrxZQtB6r/3VPZ70VCQgJycnLMPaM9e/aEm5sbzp8/X2mblv3DwNrff/QP9syQhbNnz5rP+aakpGD//v1YtWoVFAoFNm3aZJ5aXZGVK1di165dGDp0KIKDg1FUVGT+F1XZxfZ0Oh1CQkLw008/oX///nB3d4enp2eV04ir4u/vj+HDh2PevHnw8/PD2rVrsWPHDixatMj8x+auu+5CixYtMHPmTBgMBjRp0gSbNm2qcEZKu3btsHHjRqxYsQJdunQp9y/mm82dOxdbt25F37598eabb8Ld3R3ffPMNtm3bhsWLF8PV1bVGP9OtFixYgAEDBqBv376YOXMmVCoVli9fjrNnz2L9+vU1usaLm5sbNm/ejGHDhqFDhw4WF81LT0/Hvn37kJSUhB49elRrew8++CBWr16Nli1bon379jh27BiWLFlS7tpA06ZNw5dffomhQ4fi3XffhY+PD7755htcuHCh3DaffPJJjBs3DlOmTMHDDz+MmJgYLF68uNwx+OCDD2Ljxo2YMmUKRo8ejbi4OLzzzjvw8/PDpUuXLNZt164d9uzZg59//hl+fn7Q6XQV9kTI5XIsXrwYY8eOxYMPPohnn30Wer0eS5YsQVZWVrnTP3Whd+/eGDJkCFatWoXXXnsNYWFh1W7n8PBwODo64ptvvkGrVq3g7OwMf39/+Pv749NPP8XgwYMxaNAgTJgwAQEBAcjIyEBkZCSOHz+O77//vs5/tuqaNm0afvzxR9x3332YPn062rdvD5PJhNjYWGzfvh0vv/wyunXrhjfffBPx8fHo378/AgMDkZWVhY8++ghKpRK9e/cGUHWbVOSZZ55BVlYWHn74YbRt2xYKhQIXLlzAhx9+CLlcjlmzZgEoHUf18ccfY/z48cjIyMDo0aPh7e2N1NRUnDp1CqmpqVixYgWA0uMPAD766COMHz8eSqUSLVq0sKkAabckHX5MNqNsRkLZQ6VSCW9vb9G7d28xf/58i9H7ZW6dYXTo0CExcuRIERISItRqtfDw8BC9e/cWW7ZssXjfzp07RadOnYRarRYAzLNLyraXmpp6230JUTrbZejQoeKHH34Qbdq0ESqVSoSGhoqlS5eWe//FixfFwIEDhYuLi/Dy8hIvvfSS2LZtW7kZNBkZGWL06NHCzc1NyGQyi32igllYZ86cEcOGDROurq5CpVKJDh06lJstUTZT5vvvv7dYXjb7qDqzK/bv3y/69esnnJychKOjo7jnnnvEzz//XOH2qjObqUxSUpKYPXu2aN++vXBychJKpVL4+/uLYcOGia+++spixktVM94yMzPF5MmThbe3t9BqtaJXr15i//79Fc48On/+vBgwYIDQaDTC3d1dTJ48Wfz000/lPguTySQWL14smjZtKjQajejatavYtWtXhdtcuHChCA0NFWq1WrRq1Up8/vnnFR4zJ0+eFD179hRarVYAMG+nopltQgixefNm0a1bN6HRaISTk5Po37+/+PPPPy3Wqey4rWwW3a3KZjNV5MyZM0Iul4uJEycKIe6sndevXy9atmwplEpluWP31KlT4tFHHxXe3t5CqVQKX19f0a9fP7Fy5coqaxWi8tlMtx4XlbVpVW6dzSSEEHl5eeI///mPaNGihVCpVMLV1VW0a9dOTJ8+XSQlJQkhhNi6dasYPHiwCAgIMH93DRkyROzfv7/abXKr33//XUyaNEm0bt1auLq6CgcHB+Hn5ydGjRpV4QzEvXv3iqFDhwp3d3ehVCpFQECAGDp0aLnf+9mzZwt/f38hl8vvuH2ocjIheBlDIiIisl8cM0NERER2jWGGiIiI7BrDDBEREdk1hhkiIiKyawwzREREZNcYZoiIiMiuNfiL5plMJiQkJECn09Xo4mJERERU/4QQyM3Nhb+/v8UNXyvS4MNMQkJCubsaExERkX2Ii4srd5XrWzX4MFN2mei4uDi4uLhIXA0RERFVR05ODoKCgqp1u4cGH2bKTi25uLgwzBAREdmZ6gwR4QBgIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREds1B6gKIiIikEBsbi7S0NKnLqJKnpyeCg4OlLsPmMcwQEVGjExsbi5atWqGwoEDqUqrkqNXiQmQkA81tMMwQEVGjk5aWhsKCAoydtQQ+weFSl1Oh5Ngr+GbRK0hLS2OYuQ2GGSIiarR8gsMRGNFG6jKoljgAmIiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXJA0z+/btw7Bhw+Dv7w+ZTIbNmzebXyspKcGsWbPQrl07ODk5wd/fH0899RQSEhKkK5iIiIhsjqRhJj8/Hx06dMAnn3xS7rWCggIcP34cb7zxBo4fP46NGzfi4sWLGD58uASVEhERka1ykHLngwcPxuDBgyt8zdXVFTt27LBY9vHHH+Puu+9GbGwsgoOD66NEIiIisnGShpk7lZ2dDZlMBjc3t0rX0ev10Ov15uc5OTn1UBkRERFJxW4GABcVFeG1117DE088ARcXl0rXW7BgAVxdXc2PoKCgeqySiIiI6ptdhJmSkhI89thjMJlMWL58eZXrzp49G9nZ2eZHXFxcPVVJREREUrD500wlJSV49NFHER0djV27dlXZKwMAarUaarW6nqojIiIiqdl0mCkLMpcuXcLu3bvh4eEhdUlERERkYyQNM3l5ebh8+bL5eXR0NE6ePAl3d3f4+/tj9OjROH78OLZu3Qqj0YikpCQAgLu7O1QqlVRlExERkQ2RNMwcPXoUffv2NT+fMWMGAGD8+PGYN28etmzZAgDo2LGjxft2796NPn361FeZREREZMMkDTN9+vSBEKLS16t6jYiIiAiwk9lMRERERJVhmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdo1hhoiIiOwawwwRERHZNYYZIiIismsMM0RERGTXGGaIiIjIrjHMEBERkV1jmCEiIiK7xjBDREREdk3SMLNv3z4MGzYM/v7+kMlk2Lx5s8XrQgjMmzcP/v7+cHR0RJ8+fXDu3DlpiiUiIiKbJGmYyc/PR4cOHfDJJ59U+PrixYuxdOlSfPLJJzhy5Ah8fX0xYMAA5Obm1nOlREREZKscpNz54MGDMXjw4ApfE0Jg2bJlmDNnDkaNGgUAWLNmDXx8fLBu3To8++yz9VkqERER2ShJw0xVoqOjkZSUhIEDB5qXqdVq9O7dGwcPHqw0zOj1euj1evPznJycOq+ViIjKi42NRVpamtRlVCgyMlLqEsiKbDbMJCUlAQB8fHwslvv4+CAmJqbS9y1YsABvvfVWndZGRERVi42NRctWrVBYUCB1KWZyRxconNwg1+gAIaDybYbU7AIECAGZTCZ1eVQLNhtmytx6gInbHHSzZ8/GjBkzzM9zcnIQFBRUZ/UREVF5aWlpKCwowNhZS+ATHF7v+xcCyDUACQVypOnlyCqWQW8q/7djXzZwcM8VuDupEOSuRbC7FoFujpDLGW7sic2GGV9fXwClPTR+fn7m5SkpKeV6a26mVquhVqvrvD4iIro9n+BwBEa0qbf96Q1GRCbm4kx8NjIKisu9rnGQQ6NUoKgwD3k5OVC6eMJgAlJy9UjJ1eNYTCacVAq08nNB+0BX6DTKequdas5mw0xYWBh8fX2xY8cOdOrUCQBQXFyMvXv3YtGiRRJXR0REtkRvMOJYTCZOxmWhxCgAAAqZDEHujgj1cIKPiwaezio4KEon8R77Ywu+WfEKnpz3GUI7dkdyThFiMwpwLa0A+cVGHI3JxInYLLQJcMFdoe5wVtvsn0uCxGEmLy8Ply9fNj+Pjo7GyZMn4e7ujuDgYEybNg3z589HREQEIiIiMH/+fGi1WjzxxBMSVk1ERLZCCIHT8dn462o6igwmAIC7kwodAl3RwlcHtYOiyvfLZEATrQpNtCq09HWB0SRwNTUPp+KzcT2rEKfjsxGZmIMe4Z5oH+gKOcfW2CRJw8zRo0fRt29f8/OysS7jx4/H6tWr8eqrr6KwsBBTpkxBZmYmunXrhu3bt0On00lVMhER2Yj0PD3+uJCCxOwiAIC7VoXu4R4I93Kq8YBehVyGCB8dInx0iMsowMEr6UjKKcLei6mISsrFoDY+cNOqrPljkBVIGmb69OkDIUSlr8tkMsybNw/z5s2rv6KIiMimCSFw9noO9l5KhdEkoFLI0SPcA+0CXK06cDfIXYtHmzjizPVs/Hm5NNSsPxyHAa190Mzb2Wr7odrjSUAiIrIbJUYTdkYm42JyHgAgxEOL/i2962ygrkwmQ/tAN4R5OuHXs0lIzC7CtjOJuCu0Cbo39eCUbhvBG00SEZFdyCsy4Idj8biYnAeZDOjVzBMjOvjXy4wjnUaJhzsHonOwGwDgyLVM7IhMhtFU+dkFqj/smSEiIpuXmqvHllMJyNMb4KhUYGh7PwS4OdZrDQq5DPdGeKGJVoVdUSmITMxFYbERQ9v7wUHOvgEpsfWJiMimJWUX4cfj8cjTG+CuVWHMXUH1HmRu1jbAFcPa+8NBLsO19AJsO50Ig8kkWT3EMENERDbsemYhNp6Ih95ggp+rBo92DYSro/QXsgvzdMLwDv5Q3Ag0v55JgomnnCTDMENERDYpMbsQP526jhKjQGATRzzUMQBqZdXXjalPQe5ac6C5mpaPXVEpVc7QpbrDMENERDYnNVePn04moMQoEOTuiBEd/KFysL0/WcHuWgxp6wsZgHMJOThyLVPqkhol2zsyiIioUcsuLMGmE9fNp5aGtfc334bAFjX1ckbvFl4AgENX0xGVlCtxRY2P7R4dRETU6BSVGPHTyesoLDHCy1mNER39obThIFOmQ6Cbedr2zshkpObqpS2okbH9I4SIiBoFg8mEracTkVlQAme1A4Z39L/tvZVsSc9mnghyd4TBJLDtTCKKSoxSl9RoMMwQEZHkhBDYE5WK61mFUCnkGNHR3+7uVC2XyTC4rR90GgdkF5Zgx/lkDgiuJwwzREQkuTPXs3EuIQcyAEPa+cLTWS11STXiqFTgwXZ+kMuAq2n5OHM9W+qSGgWGGSIiklRCViH2XkwFAPQI90CIh5PEFdWOt4sGPZt5AgD2XUpDeh7Hz9Q1hhkiIpJMYbERv55NgkkAEd7O6BLSROqSrKJTkBuC3bUwmgR+O5fEezjVMYYZIiKShBAC288nIU9vQBOtEve38mkwd6GWyWQY2NoHGqUcaXnFOHItQ+qSGjSGGSIiksSJ2CxcSy+AQl46cNYWL4pXG05qB/Rp7g0AOHItg9O161DDOnKIiMgupOQW4c8raQCA+yI84aWzzwG/t9PcxxnhXk4widLrz/D+TXWDYYaIiOqVwWjC7+eSYRJAuJcT2gW4Sl1SnZHJZOjbwhtqBzlScvU4GZ8ldUkNEsMMERHVqz+vpCMjvxhalQL9Wno3mHEylXFSO6DXjdlNf11NR25RicQVNTwMM0REVG+uZxbiZFwWAOD+Vj7Qquzrwng11cbfBX6uGpQYBfZdSpO6nAaHYYaIiOqFwWjCHxeSAZT+cQ/ztO/rydyJstNNMhlwOSUPMen5UpfUoDDMEBFRvThyLROZBSXQqhTm0y6NiZdOjQ6BbgCAfRfTOBjYihhmiIiozqXl6XE0pvRaK32ae0GjtJ8bSFpTtzB3aJRyZBQU81YHVsQwQ0REdcokBP6ITIFJAE09ndDM21nqkiSjUSrQvakHgNLBwLyztnUwzBARUZ06E5+NpJwiqBRy9Gnh1eBnL91OW39XeDipUGQw4XA0rwxsDQwzRERUZwoMMF8cr0czD+g0Sokrkp5cLsO9EaVjhk7HZyOnkFO1a4thhoiI6sypTAeUGAX8XDVo34AvjnenQjycENTEEUYh8NfVdKnLsXsMM0REVCc0IR2QUCiHTIZGcXG8O9XjxoyuyKRcpOXxvk21wTBDRERWZzQJNOn/LwBA+wBXeDo3zHsv1Yavi8Y8GPrgFfbO1AbDDBERWd32qwVQeYVCJRe458bsHSqvR7gHZDIgOi0fyTlFUpdjtxhmiIjIqrIKirH+bC4AoLWrsdFeU6Y6mmhVaOmjAwDObKoFhhkiIrKqZTsvIa9YoDj1GsKcTVKXY/PuCnUHAFxNy0dqLsfO1ATDDBERWc3F5Fx8/VcMACDzj88h55jf22ripEJzn9KxM+ydqRmGGSIisgohBN7Zeh5Gk0C3ADWKYk5JXZLduPtG78zl1DzObKoBhhkiIrKKPRdTsf9SGlQKOcZ3cJG6HLvi4axGxI2ZTUfYO3PHGGaIiKjWTCaBxb9FAQDG9wiBr7ODxBXZn7KxMxdT8pCRXyxxNfaFYYaIiGrt59MJiEzMgU7tgCl9mkldjl3y0qkR7uUEADhyjb0zd4JhhoiIaqXYYMIH2y8CAJ7rE44mTiqJK7JfZWNnopJykctbNlUbwwwREdXKd0diEZtRAE9nNSb2DJW6HLvm7aJBmKcTBIBLubw+T3UxzBARUY3l6w346I/LAICp/ZtBq+JYmdrqEtwEABCTL4fckQOpq4NhhoiIamzVn9FIy9MjxEOLx+4OlrqcBsHfTQNvnRomIYOu0xCpy7ELDDNERFQjmfnF+HTvVQDAjAHNoVTwT4o1yGQydL7RO6PrPBTFRiFxRbaPRx4REdXIir1XkKs3oLWfC4a195e6nAalmbczHBUCCqcm2B9TKHU5Ns+mw4zBYMB//vMfhIWFwdHREU2bNsXbb78Nk4n3+iAiklJqrh5fHboGAHhlUAvIed8Cq1LIZWimMwIAtlzMhxDsnamKTY/UWrRoEVauXIk1a9agTZs2OHr0KCZOnAhXV1dMnTpV6vKIiBqtz/ZdQVGJCR2D3NCnhZfU5TRIoc4mnEouQFyOFvsvpeG+5mznyth0z8yhQ4cwYsQIDB06FKGhoRg9ejQGDhyIo0ePSl0aEVGjlZqrN99Mctr9EZDJ2CtTF1RyIO/MDgDA/x2Ilrga21ajMBMdXT+N2qtXL/zxxx+4eLH0YkynTp3CgQMHMGRI5aO79Xo9cnJyLB5ERGQ9Zb0yHYLc0Ju9BXUq9+gWyGXAvoupiErKlbocm1WjMNOsWTP07dsXa9euRVFRkbVrMps1axYef/xxtGzZEkqlEp06dcK0adPw+OOPV/qeBQsWwNXV1fwICgqqs/qIiBqbtDz2ytQnQ3Yy7g7QAAC+OHBV4mpsV43CzKlTp9CpUye8/PLL8PX1xbPPPovDhw9buzZ89913WLt2LdatW4fjx49jzZo1eP/997FmzZpK3zN79mxkZ2ebH3FxcVavi4iosfps39XSXplAV/Rhr0y9GN689H5Nm08kID1PL3E1tqlGYaZt27ZYunQprl+/jlWrViEpKQm9evVCmzZtsHTpUqSmplqluFdeeQWvvfYaHnvsMbRr1w5PPvkkpk+fjgULFlT6HrVaDRcXF4sHERHVXlrePzOYpt3fnL0y9aSlpwrtAlxRbDTh+2PxUpdjk2o1ANjBwQEjR47Ehg0bsGjRIly5cgUzZ85EYGAgnnrqKSQmJtaquIKCAsjlliUqFApOzSYiksDnN/fKcAZTvXrynhAAwDd/x8Bk4jTtW9UqzBw9ehRTpkyBn58fli5dipkzZ+LKlSvYtWsXrl+/jhEjRtSquGHDhuG9997Dtm3bcO3aNWzatAlLly7FyJEja7VdIiK6M+l5enx1qHSszFSOlal3wzr4w0XjgLiMQuy9ZJ2zHw1Jja4zs3TpUqxatQpRUVEYMmQIvvrqKwwZMsTcixIWFoZPP/0ULVu2rFVxH3/8Md544w1MmTIFKSkp8Pf3x7PPPos333yzVtslIqI78+Wf0SgsMaJdgCv6tvCWupxGx1GlwOguQfjyz2isPRTDz+AWNQozK1aswKRJkzBx4kT4+vpWuE5wcDC++OKLWhWn0+mwbNkyLFu2rFbbISKimsspKjH3yrzQtxl7ZSQy9p5gfPlnNHZFpSAuowBB7lqpS7IZNQozly5duu06KpUK48ePr8nmiYjIhqz9Kwa5RQY083bGwNY+UpfTaIV7OaNXM08cuJyG9Ydj8eoDtTv70ZDUaMzMqlWr8P3335db/v3331c5bZqIiOxLUYkRX964+uzzvcN5DyaJjbsnGADw3ZE46A1GiauxHTUKMwsXLoSnp2e55d7e3pg/f36tiyIiItuw4Wgc0vKKEeDmiOEdeWdsqd3fygc+Lmqk5xfjt7NJUpdjM2oUZmJiYhAWFlZueUhICGJjY2tdFBERSa/EaMKne0uvOvvMfU2hVNj07fwaBQeFHE/cXTpNe+2NKzFTDcOMt7c3Tp8+XW75qVOn4OHhUeuiiIhIej+fSsD1rEJ4Oqsw5i7eGsZWPHZ3EBRyGY5cy8SFJN5/EKhhmHnsscfw73//G7t374bRaITRaMSuXbswdepUPPbYY9aukYiI6pnJJLB8zxUAwMSeYdAoFRJXRGV8XDQY1KZ0IPY3f/FsCFDDMPPuu++iW7du6N+/PxwdHeHo6IiBAweiX79+HDNDRNQA7IhMxuWUPOjUDniye4jU5dAtHr+7dCDw5pPXUVTCgcA1mpqtUqnw3Xff4Z133sGpU6fg6OiIdu3aISSEBzwRkb0TQmDFjV6ZJ7uHwEWjlLgiulXPcE8EuDnielYhfjubhIc6BUhdkqRqFGbKNG/eHM2bN7dWLUREZAOOx2biZFwWVA5yTOxZfrIHSU8ul+GRroFYtvMSvjsSxzBTkzcZjUasXr0af/zxB1JSUsrd+HHXrl1WKY6IiOrf5/tKryszsmMAvHRqiauhyjzSNQgf/XEJh66mIyY9HyEeTlKXJJkahZmpU6di9erVGDp0KNq2bctLWxMRNRAx6fn4/Xzp9Usm38teGVsW4OaIeyO8sO9iKjYcjcMrgxrvFYFrFGa+/fZbbNiwAUOGDLF2PUREJKFVf16DEMB9zb3Q3EcndTl0G2O6BmHfxVT8cCwe0+9vDodGei2gGv3UKpUKzZo1s3YtREQkoeyCEmw4GgcA+Bd7ZezC/a294e6kQnKOHnsvpkpdjmRqFGZefvllfPTRRxBCWLseIiKSyPojsSgoNqKlrw69mpW/ZQ3ZHrWDAiNvDP797kicxNVIp0anmQ4cOIDdu3fj119/RZs2baBUWk7b27hxo1WKIyKi+lFsMGH1n9cAAJN7hXEspB0Zc1cQvjgQjV0XUpCaq2+Ug7ZrFGbc3NwwcuRIa9dCREQS+eVMIpJyiuClU/OGknamuY8OHYPccDIuCxuPx+PZ3uFSl1TvahRmVq1aZe06iIhIIkIIfL6/9IaS47uHQO3AWxfYm8fuCsLJuCx8dyQOz9zXtNH1rNV42LPBYMDOnTvx6aefIjc3FwCQkJCAvLw8qxVHRER176+rGTiXkAONUo6x3Xgld3v0YAd/OCoVuJqWj+OxWVKXU+9qFGZiYmLQrl07jBgxAi+88AJSU0tHUC9evBgzZ860aoFERFS3vjhQ2iszuksgmjipJK6GasJZ7YDBbX0BAD8ej5e4mvpX44vmde3aFadOnYKHh4d5+ciRI/H0009brTgiIqpYbGws0tLSar2d6zkG7Iws/QfpPU0Kcfz48VpvEwAiIyOtsh2qflu2d9FjI4CfjsdheGAxVIr6OdXk6emJ4ODgetlXZWo8m+nPP/+ESmWZ4ENCQnD9+nWrFEZERBWLjY1Fy1atUFhQUOttuQ+cAl2nISi49DeGLXrHCtVZ4tCDmsvJKA2Z48aNq+Y7ZAh4/gvku3ij/1PTUHDhQN0VdxNHrRYXIiMlDTQ1CjMmkwlGY/lbjsfHx0On4xUjiYjqUlpaGgoLCjB21hL4BNd85oreCPySoIRJAA/07Ayv/ta7rEbk4b34dc1HKCoqsto2G5vCvBwAwNBn56BF+y7Ves/ZLAWicoB2Y15FT+8ZdVkeACA59gq+WfQK0tLS7C/MDBgwAMuWLcNnn30GAJDJZMjLy8PcuXN5iwMionriExyOwIg2NX7/4egMmEQ6vHVqdGzbzKozYJJjr1htW42dh39ItT9np/xiRP0Vg2S9HE2CW8BJXaM/83anRgOAP/zwQ+zduxetW7dGUVERnnjiCYSGhuL69etYtGiRtWskIiIrM5hMOBWfBQDoFOzW6KbyNlRNnFTwddFACCAqOVfqcupNjSKbv78/Tp48ifXr1+P48eMwmUyYPHkyxo4dC0dHR2vXSEREVhaVlIuCYiOc1Q6I8ObwgIaklZ8OSTlFiEzMQefgJlKXUy9q3P/k6OiISZMmYdKkSdash4iI6pgQAiduXIukY5AbFHL2yjQkzX102HcxDWl5xY3m9gY1CjNfffVVla8/9dRTNSqGiIjqXmxGAdLzi6FUyNDW30XqcsjKNEoFwryccDklD+cTc9Bb5yV1SXWuxteZuVlJSQkKCgqgUqmg1WoZZoiIbFhZr0wbP1eolbx1QUPUyk+Hyyl5iErKRa9mng2+961GA4AzMzMtHnl5eYiKikKvXr2wfv16a9dIRERWkpanR0xGAWQAOga7SV0O1ZEQdyc4KhUoLDEiJiNf6nLqXI3vzXSriIgILFy4sFyvDRER2Y6yXplwL2e4OiqlLYbqjEIuQ0vf0oHdFxIb/qwmq4UZAFAoFEhISLDmJomIyEry9QZEJZX+Yesc4iZtMVTnysLM1bR86A3lL3TbkNRozMyWLVssngshkJiYiE8++QQ9e/a0SmFERGRdp+OzYRQCvi4a+LnyMhoNnZdODXetChkFxbiSko/WDXiwd43CzEMPPWTxXCaTwcvLC/369cMHH3xgjbqIiMiKDEYTTl/PAgB05liZRkEmk6GFrw6HrqbjQlIOw8ytTCaTtesgIqI6FJmYi6ISE1w0Dgj3cpa6HKonZWEmLrMQeXoDnBvo7Q2sOmaGiIhsjxACJ+IyAZReJE/ewKfp0j9cHZXwc9UAAC4mNdyBwDWKaDNmVP9OnEuXLq3JLoiIyEqupRcgs6AEKoUcbfxdpS6H6llLXx0Ss4twITkXnUMa5u0NahRmTpw4gePHj8NgMKBFixYAgIsXL0KhUKBz587m9XjjMiIi6R2PLe2VaRvgApUDO+QbmwgfHfZeTEVqrh7peXp4ODe82xvUKMwMGzYMOp0Oa9asQZMmpSkvMzMTEydOxL333ouXX37ZqkUSEVHNpOQWIT6zEDJZ6SkmanwclQqEeDghOi0fUcm56NEAw0yNIvoHH3yABQsWmIMMADRp0gTvvvsuZzMREdmQsovkRXg7Q6fhRfIaq7JrzkQl5UIIIXE11lejMJOTk4Pk5ORyy1NSUpCb23AHGBER2ZO8IgMuJt+4SF5wwxwrQdXT1NMJKoUcOUUGJGQXSV2O1dUozIwcORITJ07EDz/8gPj4eMTHx+OHH37A5MmTMWrUKGvXSERENXAyPgsmAQS4OcLHRSN1OSQhB4Uc4d5OAGC+CnRDUqMws3LlSgwdOhTjxo1DSEgIQkJCMHbsWAwePBjLly+3do1ERHSHig0mnL2eDYAXyaNSLX1LL5p3KTkXRlPDOtVUowHAWq0Wy5cvx5IlS3DlyhUIIdCsWTM4OTlZuz4iIqqByMQc6A0muDoqEebJ72YCAps4wkmlQH6xETHp+WjagC6eWKs5eomJiUhMTETz5s3h5ORUJ4OKrl+/jnHjxsHDwwNarRYdO3bEsWPHrL4fIqKGwiQETsRlAQA6BbvxMhkEAJDLZGhediftBnaqqUZhJj09Hf3790fz5s0xZMgQJCYmAgCefvppq07LzszMRM+ePaFUKvHrr7/i/Pnz+OCDD+Dm5ma1fRARNTRXU/ORXVgCjYMcrf0a7v146M619GmYd9KuUZiZPn06lEolYmNjodVqzcvHjBmD3377zWrFLVq0CEFBQVi1ahXuvvtuhIaGon///ggPD7faPoiIGpqyi+S1C3SFUsGL5NE/yu6kbTQJXEnJl7ocq6nRUb59+3YsWrQIgYGBFssjIiIQExNjlcIAYMuWLejatSseeeQReHt7o1OnTvj888+rfI9er0dOTo7Fg4iosUjKLkJidhHkMqBDoJvU5ZCNKbuTNgBcSGo4fx9rFGby8/MtemTKpKWlQa223pUFr169ihUrViAiIgK///47nnvuOfz73//GV199Vel7FixYAFdXV/MjKCjIavUQEdm6sl6ZFr46ODXQOyRT7ZSFmbI7aTcENQoz9913n0WgkMlkMJlMWLJkCfr27Wu14kwmEzp37oz58+ejU6dOePbZZ/Gvf/0LK1asqPQ9s2fPRnZ2tvkRFxdntXqIiGxZTmEJLqfkAQA6BfEieVQxiztpJzeMgcA1iu1LlixBnz59cPToURQXF+PVV1/FuXPnkJGRgT///NNqxfn5+aF169YWy1q1aoUff/yx0veo1Wqr9g4REdmLE3FZEACC3bXw0vF7kCpXdiftqKTcBnF16Br1zLRu3RqnT5/G3XffjQEDBiA/Px+jRo3CiRMnrDo4t2fPnoiKirJYdvHiRYSEhFhtH0REDUFRiRHnEniRPKqeCG8d5DIgJVePzPxiqcuptTvumSkpKcHAgQPx6aef4q233qqLmsymT5+OHj16YP78+Xj00Udx+PBhfPbZZ/jss8/qdL9ERPbmzPVslBgFPJxVCHYvP6aR6GaOKgWC3bW4ll6AC8m56N7UQ+qSauWOe2aUSiXOnj1bLxdhuuuuu7Bp0yasX78ebdu2xTvvvINly5Zh7Nixdb5vIiJ7YTCZcOrGRfK6BDfhRfKoWlo0oDtp1+g001NPPYUvvvjC2rVU6MEHH8SZM2dQVFSEyMhI/Otf/6qX/RIR2YuLSXnILzbCSa1A8xsXRSO6naaeznCQy5BdWILkHL3U5dRKjQYAFxcX4//+7/+wY8cOdO3atdw9mZYuXWqV4oiIqGpCCPN07I5BblDI2StD1aNykCPcyxlRybmISs6Fr6v93ln9jsLM1atXERoairNnz6Jz584ASgfk3ozdm0RE9Sc2owDp+cVQKmRo5+8qdTlkZ1r46hCVnIuLybm4t5kn5HYahu8ozERERCAxMRG7d+8GUHr7gv/+97/w8fGpk+KIiKhqx270yrT1d4VaqZC4GrI3we5aaJRyFBQbEZdZgBAP+7zD+h2Nmbl1gNCvv/6K/PyGc28HIiJ7klUsQ1xGIWSy0lNMRHdKIZchwvvGQGA7voBere5AZu+jn4mI7NmlnNKv8AhvZ7g4KiWuhuxV2aymKyn5MBhNEldTM3cUZmQyWbkxMRwjQ0RU/xQ6T8QVlH6FN4QruJJ0/F010GkcUGw0ITrNPs+23NGYGSEEJkyYYL5dQFFREZ577rlys5k2btxovQqJiKgcXZdhEJAhsIkjfFzsdxYKSU8mk6GFjw5HYzIRlZyLCDuc3n9HYWb8+PEWz8eNG2fVYoiI6Pbyi03QdRwMgL0yZB0tfEvDzLW0AhSVGKGxs8HkdxRmVq1aVVd1EBFRNe2MLoBcrYVOaUKoB29dQLXn6ayGh7MK6XnFuJySh7YB9jXNv1YDgImIqH7pDUb8fLF0XEOEzsRxi2Q1LXzsd1YTwwwRkR3ZfOI6MgpNMOSmI9jJPmeekG0qCzPxmYXIKzJIXM2dYZghIrITRpPAyr1XAQA5RzZBwU4ZsiIXRyX8b9zS4KKd9c4wzBAR2YnfzyUhOi0fzioZ8k79LnU51ACZ76TNMENERNYmhMDyPZcBAEOaOUEUF0pcETVEEd46yGVASq4eGfnFUpdTbQwzRER2YP+lNJy9ngNHpQJDIuzz/jlk+xxVCgS7l86Qi0qyn94ZhhkiIjuwYs8VAMBjdwfBRc2vbqo7LX1dAJSearKX2xbxN4KIyMadiM3EoavpUCpk+Ne9TaUuhxq4pl5OcJDLkF1YguQcvdTlVAvDDBGRjSvrlXmoYwD83RwlroYaOqVCjnAvZwD2c6qJYYaIyIZdTM7F9vPJkMmAZ3uHS10ONRI3z2oymWz/VBPDDBGRDftkV+kMpgfa+KKZt7PE1VBjEeyuhUYpR2GJEXGZBVKXc1sMM0RENupySh5+Pp0AAHipX4TE1VBjopDLEOF9o3fGDk41McwQEdmo/+2+DCGAga190NrfRepyqJFpeeNU0+XUPBiMtn3rDIYZIiIbFJ2Wj59OXgcA/Ls/e2Wo/vm5aqDTOKDEKBCdli91OVVimCEiskH/230ZJgH0b+mNtgGuUpdDjZBMJjPffPKCjZ9qYpghIrIxMen52HSCvTIkvbJZTdfS81FUYpS4msoxzBAR2Zjlu6/AaBLo08ILHYLcpC6HGjFPZzU8nFUwidIB6baKYYaIyIbEZRTgx+PxADiDiWxDSx/bn9XEMENEZEOW77kCg0ng3ghPdAlpInU5RGh+I8zEZxUit6hE4moqxjBDRGQjYtML8P3ROAAcK0O2w8VRCX83DQDgYrJtnmpimCEishHLdl6EwSTQu7kX7gp1l7ocIrOyWU1RybZ5qolhhojIBlxMzsWmG9eVmTmwhcTVEFmK8NZBLgNSc/XIyC+WupxyGGaIiGzA0u0XIQQwuK0v2gXyujJkWxxVCoR4OAGwzYHADDNERBI7HZ+F384lQSYDZgxoLnU5RBW6+VSTELZ1J22GGSIiib2//SIAYGTHAETc+INBZGuaejlBqZAhu7AEidlFUpdjgWGGiEhCf19Nx76LqXCQyzDtfvbKkO1SKuRo5u0MAIhMypG4GksMM0REEhFC4P3tUQCAMXcFIdhDK3FFRFVr5Vt69/ZLybZ1J22GGSIiieyJSsWRa5lQO8h5tV+yC4FNHOGsdoDeYLKpO2kzzBARScBgNGH+L5EAgAk9QuHrqpG4IqLbk8lkaHnj5pORNjSriWGGiEgCG47G41JKHppolZjSt5nU5RBVW1mYiUnPR5GN3EibYYaIqJ7l6Q1YuqN0rMzU/hFwdVRKXBFR9Xk4q+GtU8MkgPgC24gRtlEFEVEj8uneK0jLK0aYpxOe6BYidTlEd6yVX+lA4Jh824gRtlEFEVEjkZhdiM/3XwUAzHqgJVQO/Bom+9PcxxlyGZBVLIfSI0jqchhmiIjq0/u/X0RRiQl3h7pjUBsfqcshqhGtygGhN25v4NSmn8TV2FmYWbBgAWQyGaZNmyZ1KUREd+zs9WxsPBEPAJgztBVkMpnEFRHVXEu/0oHATm36wGiS9vYGdhNmjhw5gs8++wzt27eXuhQiojsmhMB72yIhBDCioz86BLlJXRJRrYR5OkEpE3Bw8cK5VGnvpG0XYSYvLw9jx47F559/jiZNmkhdDhHRHdt6OhGHrqZD7SDHzIEtpC6HqNYc5HIEOpVeBXjPtUJJa7GLMPPCCy9g6NChuP/++2+7rl6vR05OjsWDiEhK+XoD3ttWeoG8KX2aIcidty2ghiHM2YSsP9fhkdbOktZh82Hm22+/xfHjx7FgwYJqrb9gwQK4urqaH0FB0o+yJqLG7b+7LiEppwjB7lo827up1OUQWU0TlUD2gXXw0zlIWodNh5m4uDhMnToVa9euhUZTvUt9z549G9nZ2eZHXFxcHVdJRFS5yyl5+GJ/NABg7rDW0CgVEldE1PBIG6Vu49ixY0hJSUGXLl3My4xGI/bt24dPPvkEer0eCoXlF4NarYZara7vUomIyhFCYN6WczCYBPq39Eb/VpyKTVQXbDrM9O/fH2fOnLFYNnHiRLRs2RKzZs0qF2SIiGzJr2eTcOByGlQOcswd1kbqcogaLJsOMzqdDm3btrVY5uTkBA8Pj3LLiYhsSUGxAe9uPQ8AeK53OII9OOiXqK7Y9JgZIiJ7tXT7RSRkFyGwiSOm9AmXuhyiBs2me2YqsmfPHqlLICKq0sm4LHz5Z+mg33dGtOWgX6I6xp4ZIiIrKjaYMOuH0zAJYGSnAPRt6S11SUQNHsMMEZEVrdhzBVHJufBwUuGNB1tLXQ5Ro8AwQ0RkJReTc/HJ7ksAgHnD28DdSSVxRUSNA8MMEZEVGE0Cr/5wGiVGgftbeePB9n5Sl0TUaDDMEBFZweqD13AyLgs6tQPeeagtZDKZ1CURNRoMM0REtXQ5JQ9Lfr8AAJg9pBX8XB0lroiocWGYISKqhWKDCdO+O4GiEhPujfDEY3fx5rZE9Y1hhoioFj7ceRFnr+fATavE+490gFzO00tE9Y1hhoiohv6+mo6Ve68AABaOagcfF43EFRE1TgwzREQ1kFNUghkbTkEI4NGugXigLWcvEUmFYYaIqAbe3HwW17MKEeyuxZu8IzaRpBhmiIju0KYT8dh8MgFyGfDhmI5wVtvdbe6IGhSGGSKiO3AxORevbzwLAHipXwS6hDSRuCIiYpghIqqmPL0Bz609hsISI3o188S/+0dIXRIRgWGGiKhahBCY9eNpXE3Nh6+LBh891hEKTsMmsgkMM0RE1bDm4DVsO50IB7kM/xvbGR7OaqlLIqIbGGaIiG7jeGwm3vslEgDw+pBWHCdDZGMYZoiIqpCSU4Qpa4+jxCgwtJ0fJvYMlbokIroFwwwRUSWKSoz411dHkZRThHAvJyx8uB3vhk1kg3hxBCKqV7GxsUhLS5O6jCp5enoiKCgIL39/Cqfis+GmVeLLCXdBp1FKXRoRVYBhhojqTWxsLFq2aoXCggKpS6mSo1aLV9fswbbTKVAqZFg5rgtCPJykLouIKsEwQ0T1Ji0tDYUFBRg7awl8gsOlLqdCybFXsGnLz1h9NAUA8O5DbXFPUw+JqyKiqjDMEFG98wkOR2CEbd7PKF0vg8fgqQCAf90bhjF3BUtcERHdDsMMEdENGfnFOJjqALlShq5+arw2uJXUJRFRNXA2ExERgNyiEmw6cR3FJhn0CVGYfo8br/BLZCcYZoio0SssMWLziQTk6Q1wdhBI+eEtOCr59UhkL/jbSkSNWonRhC0nE5BRUAxntQPu9S6BqTBH6rKI6A4wzBBRo2UwmbDtTCKScoqgdpDjoY7+0HIkIZHdYZghokbJaBL45UwSYtIL4CCXYURHf948kshOMcwQUaNTGmQSEZ2WD4VchmEd/OHn6ih1WURUQwwzRNSoGE0Cv55NxNWyINPeD8HuWqnLIqJaYJghokbDaBL47VwSrqTmQyGT4cH2frxNAVEDwKFuRNQoGEwm/Ha2NMjIZcDQ9n4IZZAhahAYZoiowSsxmrD1dCJiMwqgkMkwpJ0vwjwZZIgaCoYZImrQ9CVG/HQqAYnZRVAqZHiwvT/HyBA1MAwzRNRgFRQbsPlEAlLz9FA7yDGiI2ctETVEDDNE1CBlF5Zg88nryCoogaNSgZGdAuCl43VkiBoihhkianCSc4rw08kEFJYYodM4YGSnADTRqqQui4jqCMMMETUoV9Py8OuZJBhMAl7Oagzv6A9nNb/qiBoy/oYTUYNxJj4bu6NSIAAEu2sxtJ0fVA68nBZRQ8cwQ0R2zyQEDl5Jx7GYTABAaz8X9GvpDYVcJnFlRFQfGGaIyK7pDUb8fi4Z0Wn5AIBuYe7oFuYOmYxBhqixYJghIruVXViCn08lID2/GAq5DANa+aCFr07qsoiontn0yeQFCxbgrrvugk6ng7e3Nx566CFERUVJXRYR2YD4zAJ8eyQW6fnFcFIpMLpLIIMMUSNl02Fm7969eOGFF/DXX39hx44dMBgMGDhwIPLz86UujYgkIoTAidhMbDpxHUUlJvi4qPHY3cHwddFIXRoRScSmTzP99ttvFs9XrVoFb29vHDt2DPfdd59EVRGRVEqMJuyMTMbF5DwAQAsfHe5v5Q0HhU3/u4yI6phNh5lbZWdnAwDc3d0lroSI6ltmQTG2nU5Een4x5DLg3ggvdAh05UBfIrKfMCOEwIwZM9CrVy+0bdu20vX0ej30er35eU5OTn2UR0R16HJKHnacT0ax0QStSoEh7fwQ4Fa391iKjIys0+3Xhi3XRiQFuwkzL774Ik6fPo0DBw5Uud6CBQvw1ltv1VNVRFSXDEYT9l9Kw+nrpb2y/m4aDGnrB6c6vKJvTkYqAGDcuHF1tg9rycvLk7oEIptgF2HmpZdewpYtW7Bv3z4EBgZWue7s2bMxY8YM8/OcnBwEBQXVdYlEZGUZ+cX49Wwi0vKKAQBdgpuge7hHnV8IrzCvtDd36LNz0KJ9lzrdV01FHt6LX9d8hKKiIqlLIbIJNh1mhBB46aWXsGnTJuzZswdhYWG3fY9arYZazTvjEtkrIQTOJ+ZgT1QqDCYBR6UCg9r4IMTDqV7r8PAPQWBEm3rdZ3Ulx16RugQim2LTYeaFF17AunXr8NNPP0Gn0yEpKQkA4OrqCkfHuj1fTkT1T28wYteFFPNspSB3Rwxq7Vunp5WIyP7Z9DfEihUrAAB9+vSxWL5q1SpMmDCh/gsiojqTmF2I388lI7uwBDIZ0L2pB7qGNOFsJSK6LZsOM0IIqUsgojpmMJnw99UMHIvJhACg0zhgcFtf+Lmy95WIqsemwwwRNWypuXr8fj4J6TcG+bb01aF3cy9olAqJKyMie8IwQ0T1ziSAw9EZ+Ds6HSYBOCoV6NfSG828naUujYjsEMMMEdUrB49A7El2QGZxOgAg3MsJ/Vp6Q6vi1xER1Qy/PYioXhQbTPj+fC78J/wXmcVyqB3k6NPCCy18dBzkS0S1wjBDRHXuyLUMzN54BpdT8iBzUMFHY8KDXcLgrOFXEBHVHm81S0R1JqugGK/9eBqPrDyEyyl5cFXLkbplCXp6GRhkiMhqGGaIyOqEEPjp5HXcv3Qvvj0SBwB4/O4g/PcBLxRE7gXPKhGRNfGfRkRkVZeSc/H21vPYfykNABDh7Yz5o9rhrlB3HD9+XOLqiKghYpghIqvILijBhzsv4uu/YmA0Cagc5Ph3v2Z45r5wqBzYCUxEdYdhhohqxWA0Yf2ROCzdHoXMghIAwMDWPpgztFW93xySiBonhhkiqhEhBLafT8bi3y7gSmo+AKC5jzPefLANekV4SlwdETUmDDNEdMcOR2dg4a+ROB6bBQBw0yoxY0BzPHF3MBwUPKVERPWLYYaIqu10fBY+2nkJf1xIAQBolHJM7hWGZ3uHw0WjlLg6ImqsGGaI6LZOxGbiv39cwu6oVACAQi7DmLuCMLV/BHxcNBJXR0SNHcMMEVVICIG/ozOwfM8V7LtYGmLkMuChTgF4sW8zNPXiTSGJyDYwzBCRBYPRhF/OJuH/9l/F6fhsAKU9MSNvhJhQT85QIiLbwjBDRABKbz3w/dF4rD54DdezCgEAagc5RnUOxHO9m3KaNRHZLIYZokZMCIHjsZn45q9YbD2TiGKDCQDg4aTCk91D8OQ9IfBwVktcJRFR1RhmiBqhlNwi/HwqERuOxCEqOde8vLWfC57sHoKRnQKgUSokrJCIqPoYZogaiXy9Ab+fS8KmE9fx5+U0mETpco1SjuEd/PFEtxB0CHSFjHeBJCI7wzBTS7GxsUhLS5O6jCp5enoiODhY6jKqZA/tqNfroVbb9imXWz/rjPxi/BGZjO3nk7HvYir0N04jAUDnYDeM7BSA4R0D4OrIa8QQkf1imKmF2NhYtGzVCoUFBVKXUiVHrRYXIiNtNtDYSzsCMgBC6iKq5Kh1ws/7j+FyrgN2XUjBkWsZ5h4YAGjq6YSHOgVgREd/DuglogaDYaYW0tLSUFhQgLGzlsAnOFzqciqUHHsF3yx6BWlpaTYbZuyhHSMP78Wvaz7C0GfnoEX7LlKXYyYEkG8A0vRyxGbkIynfhMkbLlus08bfBQNb+2JgGx+09NXxNBIRNTgMM1bgExyOwIg2Updh92y5HZNjrwAAPPxDJK2x2GBCWp4eSTlFSMgqRGJ2EQqKjTdedYXCCdA4yNCjmRfujfDEgNY+CGyilaxeIqL6wDBDZIOEECgoNiI1T4/U3H8eWYUl5dZVyGTwdlHDReRj78o52PvjanS7y3Z6j4iI6hrDDJGE9AYjsgpKbjyKkVlY+t+sghKLwbo3c1Y7wEunhr+rBn5ujvDRqeGgkCP+0jlsjzsLpYKnkYiocWGYIaoDQgjoDSYUFBtRUGxAXpEBuXoDcosMyC0qMf//4koCS5kmWiW8dOrSh3Ppf7Uq/toSEd2M34pE1SWTo1jIkZqrR0GxAQXFRhQWG82BpaDkn/9fWGy0mEVUFa1KATetEm6OKjTRKuGmVd14roSDQl63PxMRUQPAMEONmskkSkOIvjSc5N8IKeaAciOwZCMCwa9sxqFCOQ4djq329lUOcmhVCjirHaDTOECnVpb+V+MAnUYJZ7UDVA4MLEREtcEwQw2S3mBEXpEB+WWhRG+0CCv5N5YVlhhvvzEAgANKZzQLOCodoFUroFUqoFU5QKtSwFGlgFb1z/OyZQ5yBhUiorrGMEN2p8RoumkMSgnyigzI05c+zyu6MRbFWPVYlJvJZCgNJup/gsjNoUSrcsC1E/ux5eM3MPbVJejUo3cd/nRERHSnGGbIphiMptJgUhZQzP8tMT+vbJbPrdQOcjjdCChOqtLeFKdbQoqTWgGNUgH5bS4klwo9TAXZ4PXmiIhsD8MM1RujSSAltwgJWWUXfCtEQlYRzsdkwPepD7E1Xgn9jYvT3Y5KIYezxgE6tQOcNQ7mMSml/+VYFCKixoRhhmpNCIGcQgNS84qQkqNHap7e/N+k7H+uVJuUUwRjJVN81H4R0N/ocHGQyyyCStmg2ZtDi9pBUY8/IRER2TKGGQJQGkiKjSYUlZigLzEiV29AVkEJcgpLkH3jQm7ZhQZkFRYju7B0eVpecemVafP0t71eShkHuQw+Lhr4u2ng7+YIP1dHGHNS8d6cmXj8xdkIb94CGgc57x9ERETVxjBTQ5tOxOP/dqfD98n3sTPRAfK0azCaBAwmAeONh7kPQgBlz4T5eSkZSgegyiDDjf9V+rzs7/vNz0tfl5XblkxWusCgd4DfhI8wc0cqnA8egEwmQ4nBhCKDEfoSEwpLjCi68ajudVEq4+pYeoE375su8lYaXBzh56aBv6sjvHRqKOSWQeX48QL858phuKkEHJXscSEiojvDMFNDSdl6nEsthtq/JbJLAJSUv2dOdQiU3vnYIuGYX7EGOVQ+4biaaQAys6v1DpkMcFY5wFWrhJtWCVfH0gu6uTje/Lz04m7eLqXhxdNZDQ2DCBERSYBhpoYGtPaGMTsJr748A6Oenw3foDAo5DIo5DI4yGWQy2WQAebeldL/W9a18s+yf3KMgBBl4eafXhwhSp+XRRtx07q3Pq9oW6nx1/DjJ2/j408+QXh4MxhNAkoHOTQOcmiUpTN5HJUKaJRyqG/8V6XgaR4iIrIfDDM11Mxbhx5Bjii8chg+jgIBTRylLqlC8nSBomsn0NlPg84tvaUuh4iIyOo4d5WIiIjsGsMMERER2TWGGSIiIrJrDDNERERk1+wizCxfvhxhYWHQaDTo0qUL9u/fL3VJREREZCNsPsx89913mDZtGubMmYMTJ07g3nvvxeDBgxEbGyt1aURERGQDbD7MLF26FJMnT8bTTz+NVq1aYdmyZQgKCsKKFSukLo2IiIhsgE2HmeLiYhw7dgwDBw60WD5w4EAcPHhQoqqIiIjIltj0RfPS0tJgNBrh4+NjsdzHxwdJSUkVvkev10Ov15ufZ2eXXsI/JyfH6vXl5eUBAOIvnYO+sMDq27eG1PhoAMCxY8fM9dqaqKgoALbdjsmxVwAASdcu4oqTVuJqKsbP2jrs4bNmjbVn6/UB9lFj2fdOXl6e1f/Olm2v7Kr4VRI27Pr16wKAOHjwoMXyd999V7Ro0aLC98ydO1fgxp0A+OCDDz744IMP+37ExcXdNi/YdM+Mp6cnFApFuV6YlJSUcr01ZWbPno0ZM2aYn5tMJmRkZMDDwwMymQw5OTkICgpCXFwcXFxc6rR+W8e2+Afb4h9si3+wLf7BtvgH2+IfddkWQgjk5ubC39//tuvadJhRqVTo0qULduzYgZEjR5qX79ixAyNGjKjwPWq1Gmq12mKZm5tbufVcXFwa/UFYhm3xD7bFP9gW/2Bb/INt8Q+2xT/qqi1cXV2rtZ5NhxkAmDFjBp588kl07doV3bt3x2effYbY2Fg899xzUpdGRERENsDmw8yYMWOQnp6Ot99+G4mJiWjbti1++eUXhISESF0aERER2QCbDzMAMGXKFEyZMsUq21Kr1Zg7d265U1GNEdviH2yLf7At/sG2+Afb4h9si3/YSlvIhKjOnCciIiIi22TTF80jIiIiuh2GGSIiIrJrDDNERERk1xhmiIiIyK412DBz/fp1jBs3Dh4eHtBqtejYsSOOHTtmfn3ChAmQyWQWj3vuuUfCiutGaGhouZ9TJpPhhRdeAFB6hcV58+bB398fjo6O6NOnD86dOydx1XXjdm3RWI4JADAYDPjPf/6DsLAwODo6omnTpnj77bdhMpnM6zSWY6M6bdGYjo3c3FxMmzYNISEhcHR0RI8ePXDkyBHz643luABu3xYN+bjYt28fhg0bBn9/f8hkMmzevNni9eocB3q9Hi+99BI8PT3h5OSE4cOHIz4+vm4Krt3dk2xTRkaGCAkJERMmTBB///23iI6OFjt37hSXL182rzN+/HjxwAMPiMTERPMjPT1dwqrrRkpKisXPuGPHDgFA7N69WwghxMKFC4VOpxM//vijOHPmjBgzZozw8/MTOTk50hZeB27XFo3lmBCi9P5mHh4eYuvWrSI6Olp8//33wtnZWSxbtsy8TmM5NqrTFo3p2Hj00UdF69atxd69e8WlS5fE3LlzhYuLi4iPjxdCNJ7jQojbt0VDPi5++eUXMWfOHPHjjz8KAGLTpk0Wr1fnOHjuuedEQECA2LFjhzh+/Ljo27ev6NChgzAYDFavt0GGmVmzZolevXpVuc748ePFiBEj6qcgGzJ16lQRHh4uTCaTMJlMwtfXVyxcuND8elFRkXB1dRUrV66UsMr6cXNbCNG4jomhQ4eKSZMmWSwbNWqUGDdunBBCNKpj43ZtIUTjOTYKCgqEQqEQW7dutVjeoUMHMWfOnEZ1XNyuLYRoPMfFrWGmOsdBVlaWUCqV4ttvvzWvc/36dSGXy8Vvv/1m9Rob5GmmLVu2oGvXrnjkkUfg7e2NTp064fPPPy+33p49e+Dt7Y3mzZvjX//6F1JSUiSotv4UFxdj7dq1mDRpEmQyGaKjo5GUlISBAwea11Gr1ejduzcOHjwoYaV179a2KNNYjolevXrhjz/+wMWLFwEAp06dwoEDBzBkyBAAaFTHxu3aokxjODYMBgOMRiM0Go3FckdHRxw4cKBRHRe3a4syjeG4uFV1joNjx46hpKTEYh1/f3+0bdu2To4Vu7gC8J26evUqVqxYgRkzZuD111/H4cOH8e9//xtqtRpPPfUUAGDw4MF45JFHEBISgujoaLzxxhvo168fjh07JvmVDOvK5s2bkZWVhQkTJgCA+W7kt96B3MfHBzExMfVdXr26tS2AxnVMzJo1C9nZ2WjZsiUUCgWMRiPee+89PP744wAa17Fxu7YAGs+xodPp0L17d7zzzjto1aoVfHx8sH79evz999+IiIhoVMfF7doCaDzHxa2qcxwkJSVBpVKhSZMm5dYpe781NcgwYzKZ0LVrV8yfPx8A0KlTJ5w7dw4rVqwwh5kxY8aY12/bti26du2KkJAQbNu2DaNGjZKk7rr2xRdfYPDgweVup35zzwRQOrDr1mUNTUVt0ZiOie+++w5r167FunXr0KZNG5w8eRLTpk2Dv78/xo8fb16vMRwb1WmLxnRsfP3115g0aRICAgKgUCjQuXNnPPHEEzh+/Lh5ncZwXAC3b4vGdFxUpCbHQV0dKw3yNJOfnx9at25tsaxVq1aIjY2t8j0hISG4dOlSXZcniZiYGOzcuRNPP/20eZmvry8AlEvJKSkp5RJ3Q1JRW1SkIR8Tr7zyCl577TU89thjaNeuHZ588klMnz4dCxYsANC4jo3btUVFGvKxER4ejr179yIvLw9xcXE4fPgwSkpKEBYW1qiOC6DqtqhIQz4ublad48DX1xfFxcXIzMysdB1rapBhpmfPnoiKirJYdvHixSrvtJ2eno64uDj4+fnVdXmSWLVqFby9vTF06FDzsrIvpx07dpiXFRcXY+/evejRo4cUZdaLitqiIg35mCgoKIBcbvnrr1AozNORG9Oxcbu2qEhDPjbKODk5wc/PD5mZmfj9998xYsSIRnVc3KyitqhIYzgugOp9P3Tp0gVKpdJincTERJw9e7ZujhWrDym2AYcPHxYODg7ivffeE5cuXRLffPON0Gq1Yu3atUIIIXJzc8XLL78sDh48KKKjo8Xu3btF9+7dRUBAQIOcXmg0GkVwcLCYNWtWudcWLlwoXF1dxcaNG8WZM2fE448/3mCnWQpReVs0tmNi/PjxIiAgwDwdeePGjcLT01O8+uqr5nUay7Fxu7ZobMfGb7/9Jn799Vdx9epVsX37dtGhQwdx9913i+LiYiFE4zkuhKi6LRr6cZGbmytOnDghTpw4IQCIpUuXihMnToiYmBghRPWOg+eee04EBgaKnTt3iuPHj4t+/fpxavad+vnnn0Xbtm2FWq0WLVu2FJ999pn5tYKCAjFw4EDh5eUllEqlCA4OFuPHjxexsbESVlx3fv/9dwFAREVFlXvNZDKJuXPnCl9fX6FWq8V9990nzpw5I0GV9aOytmhsx0ROTo6YOnWqCA4OFhqNRjRt2lTMmTNH6PV68zqN5di4XVs0tmPju+++E02bNhUqlUr4+vqKF154QWRlZZlfbyzHhRBVt0VDPy52794tAJR7jB8/XghRveOgsLBQvPjii8Ld3V04OjqKBx98sM7aRyaEENbv7yEiIiKqHw1yzAwRERE1HgwzREREZNcYZoiIiMiuMcwQERGRXWOYISIiIrvGMENERER2jWGGiIiI7BrDDBEREdk1hhkiqtKECRPw0EMP1cu+QkNDsWzZsnrZl62JioqCr68vcnNza7yNM2fOIDAwEPn5+VasjMj2McwQ2ZGkpCRMnToVzZo1g0ajgY+PD3r16oWVK1eioKBA6vKqbfXq1XBzcyu3/MiRI3jmmWfqdN979uyBTCYzPzw8PNCvXz/8+eefNdpOVlaWVeqaM2cOXnjhBeh0OgDAtWvXcN9998HZ2Rm9e/dGTEyMxfpDhw7Fjz/+aLGsXbt2uPvuu/Hhhx9apSYie8EwQ2Qnrl69ik6dOmH79u2YP38+Tpw4gZ07d2L69On4+eefsXPnzkrfW1JSUo+V1pyXlxe0Wm297CsqKgqJiYnYs2cPvLy8MHToUKSkpNTLvm8VHx+PLVu2YOLEieZlL7/8MgICAnDixAn4+vpi5syZ5te+/fZbKBQKPPzww+W2NXHiRKxYsQJGo7FeaieyCXVyxycisrpBgwaJwMBAkZeXV+HrJpPJ/P8BiBUrVojhw4cLrVYr3nzzTWEwGMSkSZNEaGio0Gg0onnz5mLZsmUW2zAYDGL69OnC1dVVuLu7i1deeUU89dRTYsSIEeZ1QkJCxIcffmjxvg4dOoi5c+ean3/wwQeibdu2QqvVisDAQPH888+L3NxcIUTFN7Are++t246JiRHDhw8XTk5OQqfTiUceeUQkJSWZX587d67o0KGD+Oqrr0RISIhwcXERY8aMqfKuxWX7z8zMNC87ffq0ACC2bNliXvb111+LLl26CGdnZ+Hj4yMef/xxkZycLIQQIjo6usob8C1atEiEhYUJjUYj2rdvL77//vtK6ylrr65du1osa9Wqlfj111+FEEL88ssvonXr1kIIITIzM0V4eLj57sW30uv1Qq1Wiz/++KPKfRI1JOyZIbID6enp2L59O1544QU4OTlVuI5MJrN4PnfuXIwYMQJnzpzBpEmTYDKZEBgYiA0bNuD8+fN488038frrr2PDhg3m93zwwQf48ssv8cUXX+DAgQPIyMjApk2b7rheuVyO//73vzh79izWrFmDXbt24dVXXwUA9OjRA8uWLYOLiwsSExORmJho0etQRgiBhx56CBkZGdi7dy927NiBK1euYMyYMRbrXblyBZs3b8bWrVuxdetW7N27FwsXLqx2rQUFBVi1ahUAQKlUmpcXFxfjnXfewalTp7B582ZER0djwoQJAICgoCDzKZ6yHp6PPvoIAPCf//wHq1atwooVK3Du3DlMnz4d48aNw969eyutYd++fejatavFsg4dOmDnzp0wmUzYvn072rdvDwCYOXMmXnzxRQQHB1e4LZVKhQ4dOmD//v3VbgMiuyd1miKi2/vrr78EALFx40aL5R4eHsLJyUk4OTmJV1991bwcgJg2bdpttztlyhTx8MMPm5/7+fmJhQsXmp+XlJSIwMDAO+6ZudWGDRuEh4eH+fmqVauEq6trufVu3vb27duFQqEQsbGx5tfPnTsnAIjDhw8LIUp7ZrRarUVPzCuvvCK6detWaS1lPTNl7SaTyQQA0aVLF1FcXFzp+w4fPiwAlOthurmHJy8vT2g0GnHw4EGL906ePFk8/vjjlW67Q4cO4u2337ZYFh8fL4YOHSqCgoLE0KFDRXx8vNi7d6/o2rWrSE9PF4888ogICwsTzz77rNDr9RbvHTlypJgwYUKl+yNqaBwkzFFEdIdu7X05fPgwTCYTxo4dC71eb/Harf/SB4CVK1fi//7v/xATE4PCwkIUFxejY8eOAIDs7GwkJiaie/fu5vUdHBzQtWtXCCHuqM7du3dj/vz5OH/+PHJycmAwGFBUVIT8/PxKe5ZuFRkZiaCgIAQFBZmXtW7dGm5uboiMjMRdd90FoHQGVNmgWQDw8/Or1tiX/fv3w8nJCSdOnMCsWbOwevVqi56ZEydOYN68eTh58iQyMjJgMpkAALGxsWjdunWF2zx//jyKioowYMAAi+XFxcXo1KlTpbUUFhZCo9FYLAsICMDWrVvNz/V6PQYNGoSvvvoK7777LnQ6HaKiovDAAw/g008/xUsvvWRe19HR0a4GhBPVFsMMkR1o1qwZZDIZLly4YLG8adOmAEr/eN3q1tCwYcMGTJ8+HR988AG6d+8OnU6HJUuW4O+//76jWuRyeblwc/MA45iYGAwZMgTPPfcc3nnnHbi7u+PAgQOYPHnyHQ1EFkKUC28VLb85gAClga8seFQlLCwMbm5uaN68OYqKijBy5EicPXsWarUa+fn5GDhwIAYOHIi1a9fCy8sLsbGxGDRoEIqLiyvdZtl+t23bhoCAAIvX1Gp1pe/z9PREZmZmlfW+9957GDhwIDp37oynn34a7777LpRKJUaNGoVdu3ZZhJmMjAyEh4fftg2IGgqOmSGyAx4eHhgwYAA++eSTGl9DZP/+/ejRowemTJmCTp06oVmzZrhy5Yr5dVdXV/j5+eGvv/4yLzMYDDh27JjFdry8vJCYmGh+npOTg+joaPPzo0ePwmAw4IMPPsA999yD5s2bIyEhwWIbKpXqtrNtWrdujdjYWMTFxZmXnT9/HtnZ2WjVqtWd/fC38eSTT8JkMmH58uUAgAsXLiAtLQ0LFy7Evffei5YtW5br7VGpVABg8XO0bt0aarUasbGxaNasmcXj5h6mW3Xq1Annz5+v9PXIyEisX78eb7/9tnmfZcGwpKSkXFuePXu2yp4gooaGYYbITixfvhwGgwFdu3bFd999h8jISERFRWHt2rW4cOECFApFle9v1qwZjh49it9//x0XL17EG2+8gSNHjlisM3XqVCxcuBCbNm3ChQsXMGXKlHLXUenXrx++/vpr7N+/H2fPnsX48eMt9h0eHg6DwYCPP/4YV69exddff42VK1dabCM0NBR5eXn4448/kJaWVuEpkfvvvx/t27fH2LFjcfz4cRw+fBhPPfUUevfuXeEptNqQy+WYNm0aFi5ciIKCAgQHB0OlUpl/hi1btuCdd96xeE9ISAhkMhm2bt2K1NRU5OXlQafTYebMmZg+fTrWrFmDK1eu4MSJE/jf//6HNWvWVLr/QYMG4dChQxUGPCEEnnnmGXz44YdwdnYGAPTs2ROff/45IiMj8dVXX6Fnz57m9a9du4br16/j/vvvt1LrENkBSUfsENEdSUhIEC+++KIICwsTSqVSODs7i7vvvlssWbJE5Ofnm9cDIDZt2mTx3qKiIjFhwgTh6uoq3NzcxPPPPy9ee+010aFDB/M6JSUlYurUqcLFxUW4ubmJGTNmlJuanZ2dLR599FHh4uIigoKCxOrVq8sNAF66dKnw8/MTjo6OYtCgQeKrr74qN1j2ueeeEx4eHlaZmn2zDz/8UISEhFTahhUN3BWidPBukyZNxKJFi4QQQqxbt06EhoYKtVotunfvLrZs2SIAiBMnTpjf8/bbbwtfX18hk8kspmZ/9NFHokWLFkKpVAovLy8xaNAgsXfv3kprMhgMIiAgQPz222/lXlu5cqXFIG0hhEhOThb9+/c3t8nNn/38+fPFoEGDKt0XUUMkE+IOR/YREZHVLV++HD/99BN+//33Gm9Dr9cjIiIC69evt+itIWroOACYiMgGPPPMM8jMzERubq7F7Kw7ERMTgzlz5jDIUKPDnhkiIiKyaxwATERERHaNYYaIiIjsGsMMERER2TWGGSIiIrJrDDNERERk1xhmiIiIyK4xzBAREZFdY5ghIiIiu8YwQ0RERHbt/wHPZKMoTizmcwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check the datas if normally distributed\n",
+    "\n",
+    "# Plot the distribution of the target variable\n",
+    "sns.histplot(y_train, kde=True)\n",
+    "plt.title(\"Distribution of Graduation Rate in Training Set\")\n",
+    "plt.xlabel(\"Graduation Rate (%)\")\n",
+    "plt.ylabel(\"Frequency\")\n",
+    "plt.show()\n",
+    "# Plot the distribution of the target variable in the test set\n",
+    "sns.histplot(y_test, kde=True)\n",
+    "plt.title(\"Distribution of Graduation Rate in Test Set\")\n",
+    "plt.xlabel(\"Graduation Rate (%)\")\n",
+    "plt.ylabel(\"Frequency\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60f76cb6",
+   "metadata": {},
+   "source": [
+    "#### Importing the StandardScaler for feature scaling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 399,
+   "id": "35440b25",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>english_learners_pct</th>\n",
+       "      <th>students_with_disabilities_pct</th>\n",
+       "      <th>progress_toward_improvement_targets_pct</th>\n",
+       "      <th>in_district_expenditures_per_pupil</th>\n",
+       "      <th>student_teacher_ratio</th>\n",
+       "      <th>experienced_teachers_pct</th>\n",
+       "      <th>DOR_income_per_capita</th>\n",
+       "      <th>log_in_district_expenditures</th>\n",
+       "      <th>needs_income_avg_pct</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>district_name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Winthrop</th>\n",
+       "      <td>0.279460</td>\n",
+       "      <td>-1.010122</td>\n",
+       "      <td>0.158734</td>\n",
+       "      <td>-0.942874</td>\n",
+       "      <td>0.698806</td>\n",
+       "      <td>-1.549542</td>\n",
+       "      <td>-0.436992</td>\n",
+       "      <td>-0.590673</td>\n",
+       "      <td>0.196956</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Masconomet</th>\n",
+       "      <td>-0.795053</td>\n",
+       "      <td>0.224900</td>\n",
+       "      <td>0.388198</td>\n",
+       "      <td>0.891790</td>\n",
+       "      <td>-0.133143</td>\n",
+       "      <td>1.181490</td>\n",
+       "      <td>0.958295</td>\n",
+       "      <td>-0.469751</td>\n",
+       "      <td>-1.251717</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>North Adams</th>\n",
+       "      <td>-0.725729</td>\n",
+       "      <td>1.645176</td>\n",
+       "      <td>-0.587024</td>\n",
+       "      <td>1.084742</td>\n",
+       "      <td>-1.658384</td>\n",
+       "      <td>-1.032860</td>\n",
+       "      <td>-1.030252</td>\n",
+       "      <td>-0.733176</td>\n",
+       "      <td>1.736172</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Middleborough</th>\n",
+       "      <td>-0.552421</td>\n",
+       "      <td>-0.145606</td>\n",
+       "      <td>-1.160684</td>\n",
+       "      <td>-0.465801</td>\n",
+       "      <td>1.461426</td>\n",
+       "      <td>0.325275</td>\n",
+       "      <td>-0.551624</td>\n",
+       "      <td>0.094778</td>\n",
+       "      <td>0.204945</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Quincy</th>\n",
+       "      <td>1.076679</td>\n",
+       "      <td>0.348403</td>\n",
+       "      <td>0.158734</td>\n",
+       "      <td>-0.357807</td>\n",
+       "      <td>0.976122</td>\n",
+       "      <td>-0.161882</td>\n",
+       "      <td>-0.442582</td>\n",
+       "      <td>1.600840</td>\n",
+       "      <td>0.852055</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               english_learners_pct  students_with_disabilities_pct  \\\n",
+       "district_name                                                         \n",
+       "Winthrop                   0.279460                       -1.010122   \n",
+       "Masconomet                -0.795053                        0.224900   \n",
+       "North Adams               -0.725729                        1.645176   \n",
+       "Middleborough             -0.552421                       -0.145606   \n",
+       "Quincy                     1.076679                        0.348403   \n",
+       "\n",
+       "               progress_toward_improvement_targets_pct  \\\n",
+       "district_name                                            \n",
+       "Winthrop                                      0.158734   \n",
+       "Masconomet                                    0.388198   \n",
+       "North Adams                                  -0.587024   \n",
+       "Middleborough                                -1.160684   \n",
+       "Quincy                                        0.158734   \n",
+       "\n",
+       "               in_district_expenditures_per_pupil  student_teacher_ratio  \\\n",
+       "district_name                                                              \n",
+       "Winthrop                                -0.942874               0.698806   \n",
+       "Masconomet                               0.891790              -0.133143   \n",
+       "North Adams                              1.084742              -1.658384   \n",
+       "Middleborough                           -0.465801               1.461426   \n",
+       "Quincy                                  -0.357807               0.976122   \n",
+       "\n",
+       "               experienced_teachers_pct  DOR_income_per_capita  \\\n",
+       "district_name                                                    \n",
+       "Winthrop                      -1.549542              -0.436992   \n",
+       "Masconomet                     1.181490               0.958295   \n",
+       "North Adams                   -1.032860              -1.030252   \n",
+       "Middleborough                  0.325275              -0.551624   \n",
+       "Quincy                        -0.161882              -0.442582   \n",
+       "\n",
+       "               log_in_district_expenditures  needs_income_avg_pct  \n",
+       "district_name                                                      \n",
+       "Winthrop                          -0.590673              0.196956  \n",
+       "Masconomet                        -0.469751             -1.251717  \n",
+       "North Adams                       -0.733176              1.736172  \n",
+       "Middleborough                      0.094778              0.204945  \n",
+       "Quincy                             1.600840              0.852055  "
+      ]
+     },
+     "execution_count": 399,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Initialize the scaler\n",
+    "scaler = StandardScaler()\n",
+    "\n",
+    "# Fit the scaler on the training data and transform both training and testing data\n",
+    "X_train_scaled = scaler.fit_transform(X_train)\n",
+    "X_test_scaled = scaler.transform(X_test)\n",
+    "\n",
+    "# Convert the scaled arrays back to DataFrames\n",
+    "X_train_scaled = pd.DataFrame(X_train_scaled, columns=X_train.columns, index=X_train.index)\n",
+    "X_test_scaled = pd.DataFrame(X_test_scaled, columns=X_test.columns, index=X_test.index)\n",
+    "\n",
+    "# Print the first few rows of the scaled training data\n",
+    "X_train_scaled.head()\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "436752b4",
+   "metadata": {},
+   "source": [
+    "#### Checking the Cross validation scores and fitting the models to our train dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 400,
+   "id": "5185ea4b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cross-validation MSE scores: [16.72092747 20.24074003 17.87707817 12.96840994 17.93683746]\n",
+      "Mean MSE: 17.14879861444441\n",
+      "Standard Deviation of MSE: 2.3820252391189833\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create RandomForestRegressor model by using Crossvalidation\n",
+    "\n",
+    "\n",
+    "# Initialize the model\n",
+    "rf_model_2 = RandomForestRegressor(n_estimators=100, random_state=42)\n",
+    "\n",
+    "# Perform cross-validation\n",
+    "rf_cv_scores = cross_val_score(rf_model_2, X_train_scaled, y_train, cv=5, scoring='neg_mean_squared_error')\n",
+    "\n",
+    "# Convert negative MSE scores to positive\n",
+    "rf_cv_scores = -rf_cv_scores\n",
+    "\n",
+    "# Print the cross-validation scores\n",
+    "print(\"Cross-validation MSE scores:\", rf_cv_scores)\n",
+    "print(\"Mean MSE:\", np.mean(rf_cv_scores))\n",
+    "print(\"Standard Deviation of MSE:\", np.std(rf_cv_scores))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3104309",
+   "metadata": {},
+   "source": [
+    "#### Lets see after fitting the RF model to train dataset, see the training datasets MSE scores and R2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 401,
+   "id": "c94523e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train MSE: 2.534905244318198\n",
+      "Train R2: 0.9482348362093225\n"
+     ]
+    }
+   ],
+   "source": [
+    "#### Lets see after fitting the RF model to train dataset, see the training datasets MSE scores and R2\n",
+    "# Fit the model\n",
+    "rf_model_2.fit(X_train_scaled, y_train)\n",
+    "\n",
+    "# Predict on the training set\n",
+    "y_train_pred_rf = rf_model_2.predict(X_train_scaled)\n",
+    "\n",
+    "# Training set metrics\n",
+    "print(\"Train MSE:\", mean_squared_error(y_train, y_train_pred_rf))\n",
+    "print(\"Train R2:\", r2_score(y_train, y_train_pred_rf))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 402,
+   "id": "a6bb483a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test MSE (RF): 13.799612088888898\n",
+      "Test R2 (RF): 0.6794596454215867\n"
+     ]
+    }
+   ],
+   "source": [
+    "#use rf_model_2 to predict the graduation rate for the test set\n",
+    "y_pred_test_rf = rf_model_2.predict(X_test_scaled)\n",
+    "\n",
+    "# Calculate metrics on test set\n",
+    "test_mse_rf = mean_squared_error(y_test, y_pred_test_rf)\n",
+    "test_r2_rf = r2_score(y_test, y_pred_test_rf)\n",
+    "\n",
+    "print(\"Test MSE (RF):\", test_mse_rf)\n",
+    "print(\"Test R2 (RF):\", test_r2_rf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b604a8a7",
+   "metadata": {},
+   "source": [
+    "#### Perform Hyperparamter tuning of Random forest "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 403,
+   "id": "19971dd3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fitting 5 folds for each of 50 candidates, totalling 250 fits\n",
+      "Best Parameters: {'n_estimators': 200, 'min_samples_split': 10, 'min_samples_leaf': 2, 'max_features': 'log2', 'max_depth': None}\n",
+      "Cross-validation MSE scores: [16.95949274 18.68322745 15.95249023 12.69197294 15.0108768 ]\n",
+      "Mean MSE: 15.859612033716592\n",
+      "Standard Deviation of MSE: 1.9972709824415062\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "from sklearn.model_selection import RandomizedSearchCV\n",
+    "from sklearn.model_selection import cross_val_score\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "rf_model = RandomForestRegressor(random_state=42)\n",
+    "\n",
+    "\n",
+    "param_distributions = {\n",
+    "    'n_estimators': [100, 200, 300, 500],\n",
+    "    'max_depth': [None, 10, 20, 30, 50],\n",
+    "    'min_samples_split': [2, 5, 10],\n",
+    "    'min_samples_leaf': [1, 2, 4],\n",
+    "    'max_features': ['sqrt', 'log2']  # Removed 'auto'\n",
+    "}\n",
+    "\n",
+    "\n",
+    "\n",
+    "random_search = RandomizedSearchCV(\n",
+    "    estimator=rf_model,\n",
+    "    param_distributions=param_distributions,\n",
+    "    n_iter=50,  # Number of parameter settings sampled\n",
+    "    scoring='neg_mean_squared_error',\n",
+    "    cv=5,\n",
+    "    verbose=2,\n",
+    "    random_state=42,\n",
+    "    n_jobs=-1  # Use all available cores\n",
+    ")\n",
+    "\n",
+    "# Fit on training data\n",
+    "random_search.fit(X_train_scaled, y_train)\n",
+    "\n",
+    "#best model\n",
+    "best_rf_model = random_search.best_estimator_\n",
+    "\n",
+    "#cross-validation\n",
+    "rf_cv_scores = cross_val_score(best_rf_model, X_train_scaled, y_train, cv=5, scoring='neg_mean_squared_error')\n",
+    "rf_cv_scores = -rf_cv_scores\n",
+    "\n",
+    "print(\"Best Parameters:\", random_search.best_params_)\n",
+    "print(\"Cross-validation MSE scores:\", rf_cv_scores)\n",
+    "print(\"Mean MSE:\", np.mean(rf_cv_scores))\n",
+    "print(\"Standard Deviation of MSE:\", np.std(rf_cv_scores))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 404,
+   "id": "68bd12bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train MSE (Best RF): 6.610952942486418\n",
+      "Train R2 (Best RF): 0.8649980851760337\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check metrics for training set\n",
+    "best_rf_model.fit(X_train_scaled, y_train)\n",
+    "y_train_pred_rf_best = best_rf_model.predict(X_train_scaled)\n",
+    "\n",
+    "# Training set metrics for best RF model\n",
+    "print(\"Train MSE (Best RF):\", mean_squared_error(y_train, y_train_pred_rf_best))\n",
+    "print(\"Train R2 (Best RF):\", r2_score(y_train, y_train_pred_rf_best))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 405,
+   "id": "7480cac0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test MSE: 13.926162838327167\n",
+      "Test R2: 0.6765200974230043\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Using the best_rf_model from the first tunning.\n",
+    "\n",
+    "from sklearn.metrics import mean_squared_error, r2_score\n",
+    "\n",
+    "# Predict on test set\n",
+    "y_pred_test = best_rf_model.predict(X_test_scaled)\n",
+    "\n",
+    "# Calculate metrics on test set\n",
+    "test_mse = mean_squared_error(y_test, y_pred_test)\n",
+    "test_r2 = r2_score(y_test, y_pred_test)\n",
+    "\n",
+    "print(\"Test MSE:\", test_mse)\n",
+    "print(\"Test R2:\", test_r2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 406,
+   "id": "6d206beb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2IAAAIhCAYAAAAsFAnkAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZxJJREFUeJzt3Xl0VEXi9vGnyb4HaEISlrAFARGMoGwaQBwQUFFREHQMijgcRQcVEcZR0BEBf44yMirqaBA30AmOiAwqyqIsgso6AkaMgJCIQdIhhKQTUu8fvGlp0llJbpLO93NOn2Pfqnu7+nZzzdNVt8pmjDECAAAAAFimUW03AAAAAAAaGoIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAWGDhwoWy2Wyuh6+vr2JiYnTTTTcpNTW1xl535syZstlsFarbpk0bjRs3rsbaUtn21LY2bdq4fWahoaHq1auXFi1aZMnrF39nfvrpJ9e2AQMGaMCAAZU+1pNPPqn//Oc/1da2Yj/99JNsNpsWLlxYap377rtPNptNe/bsKbXOww8/LJvNpm+//bbCr23F9xUAahJBDAAslJycrI0bN2rVqlWaNGmSli1bpksvvVTHjh2rkde74447tHHjxho5dkPQr18/bdy4URs3bnQFo6SkJL344ou10p4XXnhBL7zwQqX3q6kgVhHjx4+XJL322msey4uKirRo0SJdeOGFuuiii6xsGgDUKoIYAFioa9eu6t27twYMGKCHH35Y06ZN05EjR2rsj+SWLVuqd+/eNXLshiAyMlK9e/dW7969dcMNN2jlypUKDw/XM888U+o+p06dUn5+fo20p0uXLurSpUuNHLumdO3aVZdcconeeOMNFRYWlij/5JNP9PPPP7sCGwA0FAQxAKhFPXv2lCT98ssvbtu//vprXXPNNWrSpIkCAwOVkJCgd999161Obm6upkyZorZt2yowMFBNmjRRz5499c4777jqeBoKWFBQoKlTpyo6OlrBwcG69NJLtXnz5hJtK20Yoachc0uWLNHgwYMVExOjoKAgde7cWdOmTdOJEyfKPQeff/65BgwYoKZNmyooKEitW7fWyJEjlZubW+o+1157reLi4lRUVFSirFevXm49K++995569eqliIgIBQcHq127drr99tvLbZcnkZGROu+887R//35Jvw/Ne+qpp/TEE0+obdu2CggI0OrVqyVV7HOUpE2bNqlfv34KDAxUbGyspk+froKCghL1PA1NzM/P1+OPP67OnTsrMDBQTZs21cCBA7VhwwZJks1m04kTJ/T666+7hlmeeYyMjAz96U9/UsuWLeXv76+2bdvqscceKxGaDh8+rFGjRiksLEwREREaPXq0MjIyKnTexo8fr4yMDP33v/8tUZacnKyAgADdfPPNysvL0wMPPKALL7xQERERatKkifr06aMPPvig3Nfw9L2UpDVr1shms2nNmjVu21etWqVBgwYpPDxcwcHB6tevnz777DO3Or/++qvuvPNOtWrVSgEBAWrWrJn69eunVatWVeh9A0BZfGu7AQDQkKWlpUmSOnbs6Nq2evVqXXnllerVq5cWLFigiIgILV68WKNHj1Zubq7rvpj7779fb7zxhp544gklJCToxIkT2rVrl44ePVrma06YMEGLFi3SlClT9Ic//EG7du3S9ddfr+PHj1f5faSmpmrYsGGaPHmyQkJCtGfPHs2dO1ebN2/W559/Xup+P/30k4YPH67LLrtMr732miIjI3Xo0CGtXLlSTqdTwcHBHve7/fbbNWLECH3++ee64oorXNv37NmjzZs367nnnpMkbdy4UaNHj9bo0aM1c+ZMBQYGav/+/WW2qSwFBQXav3+/mjVr5rb9ueeeU8eOHfX0008rPDxc8fHxFf4cv/vuOw0aNEht2rTRwoULFRwcrBdeeEFvv/12ue0pLCzU0KFD9cUXX2jy5Mm6/PLLVVhYqE2bNunAgQPq27evNm7cqMsvv1wDBw7UI488IkkKDw+XdDqEXXLJJWrUqJEeffRRtW/fXhs3btQTTzyhn376ScnJyZKkkydP6oorrtDhw4c1e/ZsdezYUR999JFGjx5dofM2ZswY3XfffXrttdd09dVXu7YfO3ZMH3zwga677jo1btxYDodDv/32m6ZMmaIWLVrI6XRq1apVuv7665WcnKxbb721Qq9XnjfffFO33nqrRowYoddff11+fn566aWXNGTIEH388ccaNGiQJOmPf/yjvv32W82aNUsdO3ZUVlaWvv3223L/jQFAhRgAQI1LTk42ksymTZtMQUGBOX78uFm5cqWJjo42iYmJpqCgwFW3U6dOJiEhwW2bMcZcddVVJiYmxpw6dcoYY0zXrl3NtddeW+brzpgxw5x5qd+9e7eRZO677z63em+99ZaRZJKSkkrd9+z3kpaW5vE1i4qKTEFBgVm7dq2RZLZv317qMf/9738bSWbbtm1lvo+zFRQUmObNm5uxY8e6bZ86darx9/c3mZmZxhhjnn76aSPJZGVlVer4xhgTFxdnhg0bZgoKCkxBQYFJS0szSUlJRpJ58MEHjTHGpKWlGUmmffv2xul0uu1f0c9x9OjRJigoyGRkZLjqFBYWmk6dOpU4z/379zf9+/d3PV+0aJGRZF555ZUy30tISIjbZ1vsT3/6kwkNDTX79+9321583v73v/8ZY4x58cUXjSTzwQcfuNWbMGGCkWSSk5PLfH1jjElKSjJ+fn7ml19+cW2bP3++kWQ+/fRTj/sUFhaagoICM378eJOQkOBWFhcX5/aeSvterl692kgyq1evNsYYc+LECdOkSRNz9dVXu9U7deqU6d69u7nkkktc20JDQ83kyZPLfW8AUBUMTQQAC/Xu3Vt+fn4KCwvTlVdeqcaNG+uDDz6Qr+/pAQo//PCD9uzZo5tvvlnS6R6P4sewYcOUnp6uvXv3SpIuueQS/fe//9W0adO0Zs0anTx5stzXLx4yV3z8YqNGjXK1oSp+/PFHjR07VtHR0fLx8ZGfn5/69+8vSdq9e3ep+1144YXy9/fXnXfeqddff10//vhjhV7P19dXt9xyi5YuXSqHwyHp9L1Zb7zxhkaMGKGmTZtKki6++GLX+3v33Xd16NChSr2vFStWyM/PT35+fmrbtq3effdd3XPPPXriiSfc6l1zzTXy8/NzPa/M57h69WoNGjRIzZs3d+3v4+NTod6m//73vwoMDKzyUMvly5dr4MCBio2NdWvj0KFDJUlr1651tTEsLEzXXHON2/5jx46t8GuNHz9eBQUFeuONN1zbkpOTFRcX5+qBkk4PJe3Xr59CQ0Pl6+srPz8/vfrqq2V+jypjw4YN+u2335SUlOT2nouKinTllVdqy5YtriG1l1xyiRYuXKgnnnhCmzZt8jhcFACqiiAGABZatGiRtmzZos8//1x/+tOftHv3bo0ZM8ZVXnyv2JQpU1wBoPhx1113SZIyMzMlnR4O99BDD+k///mPBg4cqCZNmujaa68tczr84iFV0dHRbtt9fX1d4aWycnJydNlll+mrr77SE088oTVr1mjLli1aunSpJJUZENu3b69Vq1YpKipKd999t9q3b6/27dvrH//4R7mve/vttysvL0+LFy+WJH388cdKT0/Xbbfd5qqTmJio//znPyosLNStt96qli1bqmvXrm730ZXl0ksv1ZYtW/T111/ru+++U1ZWlp577jn5+/u71YuJiXF7XpnP8ejRoyU+D6nkZ+TJr7/+qtjYWDVqVLX/nf/yyy/68MMPS7Tx/PPPL9HGM4NiZdpY7LLLLlPHjh1dwx137Nihb7/9VrfddpvrXsSlS5dq1KhRatGihd58801t3LhRW7ZscX3W1aH4s7nhhhtKvO+5c+fKGKPffvtN0ul7H5OSkvSvf/1Lffr0UZMmTXTrrbdW+N44ACgL94gBgIU6d+7smqBj4MCBOnXqlP71r3/p3//+t2644QbZ7XZJ0vTp03X99dd7PMZ5550nSQoJCdFjjz2mxx57TL/88ourd+zqq68udc2m4rCVkZGhFi1auLYXFhaWuO8lMDBQ0unJIAICAlzbi/84L/b555/r8OHDWrNmjasXTJKysrLKPR/S6T/QL7vsMp06dUpff/215s+fr8mTJ6t58+a66aabSt2vS5cuuuSSS5ScnKw//elPSk5OVmxsrAYPHuxWb8SIERoxYoTy8/O1adMmzZ49W2PHjlWbNm3Up0+fMtsWERHh+rzKcvakJpX5HJs2berxD/uK/LHfrFkzffnllyoqKqpSGLPb7erWrZtmzZrlsTw2NtbVRk8TulQ2kNx+++2aNm2aNm/erLfffluNGjVyWwvszTffVNu2bbVkyRK3c1qRWSjP/L6e6ezva/FnM3/+/FJnFC0OnXa7XfPmzdO8efN04MABLVu2zDXT6cqVK8t/wwBQBnrEAKAWPfXUU2rcuLEeffRRFRUV6bzzzlN8fLy2b9+unj17enyEhYWVOE7z5s01btw4jRkzRnv37i11xsHi2fLeeustt+3vvvtuiVny2rRpI+l0z8WZPvzwQ7fnxX8wnxnWJOmll14q+82fxcfHR7169dLzzz8vSRVa3Pe2227TV199pS+//FIffvihkpKS5OPj47FuQECA+vfvr7lz50qStm7dWqn2VUZlPseBAwfqs88+c5s589SpU1qyZEm5rzN06FDl5eWVuaCydPq9e+qZvOqqq7Rr1y61b9/eYxuLg9jAgQN1/PhxLVu2zG3/ikwocqakpCT5+vrqpZde0ltvvaVBgwYpLi7OVW6z2eTv7+8WwjIyMio0a2Jp39ez29yvXz9FRkbqu+++K/WzObvHU5Jat26tSZMm6Q9/+EOlFp4GgNLQIwYAtahx48aaPn26pk6dqrffflu33HKLXnrpJQ0dOlRDhgzRuHHj1KJFC/3222/avXu3vv32W7333nuSTk/TftVVV6lbt25q3Lixdu/erTfeeEN9+vQpdbbBzp0765ZbbtG8efPk5+enK664Qrt27XLN9nemYcOGqUmTJho/frwef/xx+fr6auHChTp48KBbvb59+6px48aaOHGiZsyYIT8/P7311lvavn17ue9/wYIF+vzzzzV8+HC1bt1aeXl5roV/z5wNsTRjxozR/fffrzFjxig/P9+td0WSHn30Uf38888aNGiQWrZsqaysLP3jH/9wu4etplT0c/zrX/+qZcuW6fLLL9ejjz6q4OBgPf/88xWa+n/MmDFKTk7WxIkTtXfvXg0cOFBFRUX66quv1LlzZ1eP4gUXXKA1a9boww8/VExMjMLCwnTeeefp8ccf16effqq+ffvq3nvv1Xnnnae8vDz99NNPWrFihRYsWKCWLVvq1ltv1bPPPqtbb71Vs2bNUnx8vFasWKGPP/64UuckOjpaw4YNU3JysowxJdYOu+qqq7R06VLddddduuGGG3Tw4EH97W9/U0xMTJlDbqXT9wOed955mjJligoLC9W4cWO9//77+vLLL93qhYaGav78+UpKStJvv/2mG264QVFRUfr111+1fft2/frrr3rxxRflcDg0cOBAjR07Vp06dVJYWJi2bNmilStXltrLCQCVUtuzhQBAQ1A8o9uWLVtKlJ08edK0bt3axMfHm8LCQmOMMdu3bzejRo0yUVFRxs/Pz0RHR5vLL7/cLFiwwLXftGnTTM+ePU3jxo1NQECAadeunbnvvvtcMwYa43nmw/z8fPPAAw+YqKgoExgYaHr37m02btxYYhY6Y4zZvHmz6du3rwkJCTEtWrQwM2bMMP/6179KzE63YcMG06dPHxMcHGyaNWtm7rjjDvPtt9+WmFHv7PZs3LjRXHfddSYuLs4EBASYpk2bmv79+5tly5ZV+NyOHTvWSDL9+vUrUbZ8+XIzdOhQ06JFC+Pv72+ioqLMsGHDzBdffFHucePi4szw4cPLrFM8a+L//d//eSyvyOdojDHr1683vXv3NgEBASY6Oto8+OCD5uWXXy531kRjTn9/Hn30URMfH2/8/f1N06ZNzeWXX242bNjgqrNt2zbTr18/ExwcbCS5HePXX3819957r2nbtq3x8/MzTZo0MT169DAPP/ywycnJcdX7+eefzciRI01oaKgJCwszI0eONBs2bKjwrInFPvjgAyPJNGnSxOTl5ZUonzNnjmnTpo0JCAgwnTt3Nq+88orH77Gn7+v3339vBg8ebMLDw02zZs3MPffcYz766CO3WROLrV271gwfPtw0adLE+Pn5mRYtWpjhw4eb9957zxhjTF5enpk4caLp1q2bCQ8PN0FBQea8884zM2bMMCdOnKjw+wWA0tiMMaZWEiAAAAAANFDcIwYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxVjQuRoUFRXp8OHDCgsLk81mq+3mAAAAAKglxhgdP35csbGxatSo9H4vglg1OHz4sFq1alXbzQAAAABQRxw8eFAtW7YstZwgVg3CwsIknT7Z4eHhtdwaAAAAALUlOztbrVq1cmWE0hDEqkHxcMTw8HCCGAAAAIByb1lisg4AAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAs5lvbDQAAwBs5cp3KzHEqO69A4UF+sof4KyLYv7abBQCoIwhiAABUs8NZJ/VQyg59kZrp2pYYb9eckd0UGxlUiy0DANQVDE0EAKAaOXKdJUKYJK1LzdS0lB1y5DprqWUAgLqEIAYAQDXKzHGWCGHF1qVmKjOHIAYAIIgBAFCtsvMKyiw/Xk45AKBhIIgBAFCNwgP9yiwPK6ccANAwEMQAAKhG9lB/JcbbPZYlxttlD2XmRAAAQQwAgGoVEeyvOSO7lQhjifF2zR3ZjSnsAQCSmL4eAIBqFxsZpPljEpSZ49TxvAKFBfrJHso6YgCA3xHEAACoARHBBC8AQOkYmggAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMW8Koi1adNGNputxOPuu+/2WH/NmjUe6+/Zs8filgMAAABoSHxruwHVacuWLTp16pTr+a5du/SHP/xBN954Y5n77d27V+Hh4a7nzZo1q7E2AgAAAIBXBbGzA9ScOXPUvn179e/fv8z9oqKiFBkZWeHXyc/PV35+vut5dnZ2pdoJAAAAoGHzqqGJZ3I6nXrzzTd1++23y2azlVk3ISFBMTExGjRokFavXl3usWfPnq2IiAjXo1WrVtXVbAAAAAANgNcGsf/85z/KysrSuHHjSq0TExOjl19+WSkpKVq6dKnOO+88DRo0SOvWrSvz2NOnT5fD4XA9Dh48WM2tBwAAAODNbMYYU9uNqAlDhgyRv7+/Pvzww0rtd/XVV8tms2nZsmUV3ic7O1sRERFyOBxu95oBAAAAaFgqmg28skds//79WrVqle64445K79u7d2+lpqbWQKsAAABqhyPXqX1HcrT1wDHt+zVHjlxnbTcJaPC8arKOYsnJyYqKitLw4cMrve/WrVsVExNTA60CAACw3uGsk3ooZYe+SM10bUuMt2vOyG6KjQyqxZYBDZvXBbGioiIlJycrKSlJvr7ub2/69Ok6dOiQFi1aJEmaN2+e2rRpo/PPP981uUdKSopSUlJqo+kAAADVypHrLBHCJGldaqampezQ/DEJigj2r6XWAQ2b1wWxVatW6cCBA7r99ttLlKWnp+vAgQOu506nU1OmTNGhQ4cUFBSk888/Xx999JGGDRtmZZMBAABqRGaOs0QIK7YuNVOZOU6CGFBLvHayDisxWQcAAKiLth44pute2FBq+X/u6qsLWze2sEWA92vQk3UAAABACg/0K7M8rJxyADWHIAYAAOCl7KH+Soy3eyxLjLfLHsqwRKC2EMQAAAC8VESwv+aM7FYijCXG2zV3ZDfuDwNqkddN1gEAAIDfxUYGaf6YBGXmOHU8r0BhgX6yh/oTwoBaRhADAADwchHBBC+grmFoIgAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMVYRwwAUCZHrlOZOU5l5xUoPMhP9hDWIwIA4FwRxAAApTqcdVIPpezQF6mZrm2J8XbNGdlNsZFBtdgyAADqN4YmAgA8cuQ6S4QwSVqXmqlpKTvkyHXWUssAAKj/CGIAAI8yc5wlQlixdamZyswhiAEAUFUEMQCAR9l5BWWWHy+nHAAAlI4gBgDwKDzQr8zysHLKAQBA6QhiAACP7KH+Soy3eyxLjLfLHsrMiQAAVBVBDADgUUSwv+aM7FYijCXG2zV3ZDemsAcA4BwwfT0AeKHqWvsrNjJI88ckKDPHqeN5BQoL9JM9lHXEAAA4VwQxAPAy1b32V0QwwQsAgOrG0EQA8CKs/QUAQP1AEAMAL8LaXwAA1A8EMQDwIqz9BQBA/UAQAwAvwtpfAADUDwQxAPAirP0FAED9QBADAC/C2l8AANQPTF8PAF6Gtb8AAKj7CGIA4IVY+wsAgLqNoYkAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYzLe2GwAAAADAWo5cpzJznMrOK1B4kJ/sIf6KCPav7WY1KF7VIzZz5kzZbDa3R3R0dJn7rF27Vj169FBgYKDatWunBQsWWNRaAAAAwHqHs05q0jtbNeiZtbruhQ0a9Pe1uuedrTqcdbK2m9ageFUQk6Tzzz9f6enprsfOnTtLrZuWlqZhw4bpsssu09atW/WXv/xF9957r1JSUixsMQAAAGANR65TD6Xs0BepmW7b16VmalrKDjlynbXUsobH64Ym+vr6ltsLVmzBggVq3bq15s2bJ0nq3Lmzvv76az399NMaOXJkDbYSAAAAsF5mjrNECCu2LjVTmTlOhihaxOt6xFJTUxUbG6u2bdvqpptu0o8//lhq3Y0bN2rw4MFu24YMGaKvv/5aBQUFpe6Xn5+v7OxstwcAAABQ12Xnlf43riQdL6cc1cerglivXr20aNEiffzxx3rllVeUkZGhvn376ujRox7rZ2RkqHnz5m7bmjdvrsLCQmVmev6lQJJmz56tiIgI16NVq1bV+j4AAACAmhAe6FdmeVg55ag+XhXEhg4dqpEjR+qCCy7QFVdcoY8++kiS9Prrr5e6j81mc3tujPG4/UzTp0+Xw+FwPQ4ePFgNrQcAAABqlj3UX4nxdo9lifF22UMZlmgVrwpiZwsJCdEFF1yg1NRUj+XR0dHKyMhw23bkyBH5+vqqadOmpR43ICBA4eHhbg8AAACgrosI9teckd1KhLHEeLvmjuzG/WEW8rrJOs6Un5+v3bt367LLLvNY3qdPH3344Ydu2z755BP17NlTfn50ywIAAMD7xEYGaf6YBGXmOHU8r0BhgX6yh7KOmNW8qkdsypQpWrt2rdLS0vTVV1/phhtuUHZ2tpKSkiSdHlJ46623uupPnDhR+/fv1/3336/du3frtdde06uvvqopU6bU1lsAAAAAalxEsL/aR4XqwtaN1T4qlBBWC7yqR+znn3/WmDFjlJmZqWbNmql3797atGmT4uLiJEnp6ek6cOCAq37btm21YsUK3XfffXr++ecVGxur5557jqnrAQAAANQomymenQJVlp2drYiICDkcDu4XAwAAABqwimYDrxqaCAAAAAD1AUEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGK+td0AAABQvzhyncrMcSo7r0DhQX6yh/grIti/tpsFAPUKQQwAAFTY4ayTeihlh75IzXRtS4y3a87IboqNDKrFlgFA/cLQRAAAUCGOXGeJECZJ61IzNS1lhxy5zlpqGQDUPwQxAABQIZk5zhIhrNi61Exl5hDEAKCiGJoIwGtxHwtQvbLzCsosP15OOQDgdwQxAF6J+1iA6hce6FdmeVg55QCA3zE0EYDX4T4WoGbYQ/2VGG/3WJYYb5c9lB5nAKgoghgAr8N9LEDNiAj215yR3UqEscR4u+aO7MbQXwCoBIYmAvA63McC1JzYyCDNH5OgzBynjucVKCzQT/ZQ7r8EgMryqh6x2bNn6+KLL1ZYWJiioqJ07bXXau/evWXus2bNGtlsthKPPXv2WNRqANWN+1iAmhUR7K/2UaG6sHVjtY8KJYQBQBV4VRBbu3at7r77bm3atEmffvqpCgsLNXjwYJ04caLcfffu3av09HTXIz4+3oIWA6gJ3McCAADqOq8amrhy5Uq358nJyYqKitI333yjxMTEMveNiopSZGRkDbYOgFWK72OZlrJD686aNZH7WAAAQF3gVUHsbA6HQ5LUpEmTcusmJCQoLy9PXbp00V//+lcNHDiw1Lr5+fnKz893Pc/Ozj73xgKoVtzHAgAA6jKvDWLGGN1///269NJL1bVr11LrxcTE6OWXX1aPHj2Un5+vN954Q4MGDdKaNWtK7UWbPXu2HnvssZpqOoBqEhFM8AIAoLY4cp3KzHEqO69A4UF+sofw/+Uz2YwxprYbURPuvvtuffTRR/ryyy/VsmXLSu179dVXy2azadmyZR7LPfWItWrVSg6HQ+Hh4efUbgAAAKC+O5x1ssSanonxds0Z2U2xkUG12LKal52drYiIiHKzgVdN1lHsnnvu0bJly7R69epKhzBJ6t27t1JTU0stDwgIUHh4uNsDAAAAwOmesLNDmHR6Lc9pKTvkyGU9T8nLgpgxRpMmTdLSpUv1+eefq23btlU6ztatWxUTE1PNrQMAAAC8X2aOs0QIK7YuNVOZOQQxycvuEbv77rv19ttv64MPPlBYWJgyMjIkSREREQoKOt0FOn36dB06dEiLFi2SJM2bN09t2rTR+eefL6fTqTfffFMpKSlKSUmptfcBAAAA1FfZeQVllh8vp7yh8Kog9uKLL0qSBgwY4LY9OTlZ48aNkySlp6frwIEDrjKn06kpU6bo0KFDCgoK0vnnn6+PPvpIw4YNs6rZAAAAQK2rrsk1wgP9yiwPK6e8ofDayTqsVNEb8gAAAIC6qDon13DkOnXPO1vd1vI885jzxyR49eyJDXqyDgAAAAAVU92Ta0QE+2vOyG5KjLe7bU+Mt2vuyG5eHcIqw6uGJgIAAAConIpMrlHZ8BQbGaT5YxKUmePU8bwChQX6yR7KOmJnIogBAAAADVhNTa4REUzwKgtDEwEAAIAGjMk1agdBDAAAAGjA7KH+Je7nKpYYb5c9lF6tmkAQAwAAABqw6p5cw5Hr1L4jOdp64Jj2/ZpT6ck+Ksvq16su3CMGAAAANHDVNblGdU6DXxdfrzqxjlg1YB0xAEBDVV0LwAKo/xy5Tk16Z6vHGRhrYv0wq1+voiqaDegRAwAAVVKff4kGUP2qMg3+ufyYUxPT7luJIAYAACqtvAVga+uXaAC1p7LT4J/rjzk1Ne2+VZisAwAAVFpFfokG0LBUZhr88n7MqciEG/V92n2CGAAAqLT6/ks0gOpXmWnwq+PHnPo+7T5BDAAAVFp9/yUa8CZ1Zfr2ykyDXx0/5lT3tPtW4x4xAABQacW/RK8rZbayuv5LNOAt6tqkORWdBr+6fsyprmn3awM9YgAAoNLq+y/RgDeojvusakJEsL/aR4XqwtaN1T4q1OP1oDqHFVbk9eoiesQAAECV1OdfogFvUJ+nby/+MWdayg63nvWG9GMOQQwAAFRZRDDBC6gtxfdZBfv76PZL2yqhVaTyC4sU6Oejbw8c04n8uj1pTkP/MYcgBgAAANRD4YF+Cvb30XNjEpS8Pk3//PwHV1m/Dk11w0Uta7F1FdOQf8zhHjEAAACgHrKH+uuRq7ooeX2a1v9w1K1s/Q9H9egHu2rtPjGUjyAGAAAA1EMRwf66qHVkiRBWjMXV6zaCGAAAAFBP5TpPlVnO4up1F/eIAQAAAPVUbS2u7sh1KjPHqey8AoUH+cke0nDv9aoqghgAAABQT9XG4up1bRHp+oqhiQAAAEA9ZfXi6nV1Een6iB4xAAAAoB6zcj2u+ryIdF1DEAMAAADqOavW48ouZ/IPJgepOIYmAgAAAKiQ2pocxBsRxAAAAABUSPHkIJ7U1OQg3oogBgAAAKBCrJ4cxJtVyz1ip06d0s6dOxUXF6fGjRtXxyEBAAAA1EFWTg7izarUIzZ58mS9+uqrkk6HsP79++uiiy5Sq1attGbNmupsHwAAAIA6JiLYX+2jQnVh68ZqHxVKCKuCKgWxf//73+revbsk6cMPP1RaWpr27NmjyZMn6+GHH67WBgIAAHgLR65T+47kaOuBY9r3aw5rLgENWJWGJmZmZio6OlqStGLFCt14443q2LGjxo8fr+eee65aGwgAAOANDmedLLEQbmK8XXNGdlNsZFAttqx6OXKdysxxKjuvQOFBfrKHMGQN8KRKQax58+b67rvvFBMTo5UrV+qFF16QJOXm5srHx6daGwgAAFDfOXKdJUKYdHoB3GkpOzR/TIJXhJWGEjaB6lCloYm33XabRo0apa5du8pms+kPf/iDJOmrr75Sp06dqrWBAAAA9V1mjrNECCu2LjVTmTn1f4hieWGTYZiVx1BW71alHrGZM2eqa9euOnjwoG688UYFBARIknx8fDRt2rRqbSAAAEB9l51XUGb58XLK64OKhE1v6PWzCr2L3q/K09ffcMMNJbYlJSWdU2MAAAC8UXigX5nlYeWU1wcNIWxapaEMZW3oKhzEKjMJx7333lulxgAAAHgje6i/EuPtWuehxygx3i57aP3/o7ohhE2r0LvYMFQ4iD377LMVqmez2QhiAAAAZ4gI9teckd00LWWHWxhLjLdr7shuXvFHdUMIm1ahd7FhqHAQS0tLq8l2AAAAeLXYyCDNH5OgzBynjucVKCzQT/ZQ75navSGETas0xN7FhrjsQZXvEQMAAEDlRAR79x+X3h42rdLQehcb6sQkNmOMqcqOP//8s5YtW6YDBw7I6XSfSvOZZ56plsbVF9nZ2YqIiJDD4VB4eHhtNwcAAAD13OGsk6X2LsZ4UThx5Do16Z2tHu+JS4y318uJSSqaDarUI/bZZ5/pmmuuUdu2bbV371517dpVP/30k4wxuuiii6rcaAAAAAANp3exIU9MUqUFnadPn64HHnhAu3btUmBgoFJSUnTw4EH1799fN954Y3W3EQAAAGhwIoL91T4qVBe2bqz2UaFeGUga8sQkVQpiu3fvdq0Z5uvrq5MnTyo0NFSPP/645s6dW60NBAAAAOCdGuLEJMWqFMRCQkKUn58vSYqNjdW+fftcZZmZnrsWAQAAAOBMxROTeOKNE5OcqUpBrHfv3lq/fr0kafjw4XrggQc0a9Ys3X777erdu3e1NrAqXnjhBbVt21aBgYHq0aOHvvjiizLrr127Vj169FBgYKDatWunBQsWWNRSAAAAoPY4cp3adyRHWw8c075fc+TIdZa/UzUqXvbg7DDWEJY9qNJkHc8884xycnIkSTNnzlROTo6WLFmiDh06VHjh55qyZMkSTZ48WS+88IL69eunl156SUOHDtV3332n1q1bl6iflpamYcOGacKECXrzzTe1fv163XXXXWrWrJlGjhxZC+8AAACg7miI6zs1FJ6mjb8s3q7Z112glk2CLWtHQ5mY5GxVnr6+rurVq5cuuugivfjii65tnTt31rXXXqvZs2eXqP/QQw9p2bJl2r17t2vbxIkTtX37dm3cuLFCr+maovLwYc9TVPr4SIGBvz8/caL0gzVqJAUFVa1ubq5U2sdps0nBwVWre/KkVFRUejtCQqpWNy9POnWqeuoGB59utyTl50uFhdVTNyjo9HmWJKdTKijjhtHK1A0MPP29qGzdgoLT9UsTECD5+la+bmHh6XNRGn9/yc+v8nVPnTr92ZXGz+90/crWLSo6/V2rjrq+vqfPhXT630RubvXUrcy/e64Rnutyjah8Xa4Rp/+ba0TV6nr4d5+edVKPfLBLX+47qjy/021IjLdr7tAOiokIlEd15BrhsPm5AmSE7ZSaBvqU/od9A7xGOHKdeuC97Vr/w1FXVaevn0418tGlHZpq7jWd1SKkjD4brhGnefh3n52drYjY2PKXtjJeJD8/3/j4+JilS5e6bb/33ntNYmKix30uu+wyc++997ptW7p0qfH19TVOp9PjPnl5ecbhcLgeBw8eNJKM4/TpL/kYNsz9AMHBnutJxvTv717Xbi+9bs+e7nXj4kqv26WLe90uXUqvGxfnXrdnz9Lr2u3udfv3L71ucLB73WHDSq979lfzhhvKrpuT83vdpKSy6x458nvdu+4qu25a2u91p0wpu+6uXb/XnTGj7LqbN/9e96mnyq67evXvdf/5z7LrLl/+e93k5LLrvvvu73XffbfsusnJv9ddvrzsuv/85+91V68uu+5TT/1ed/PmsuvOmPF73V27yq47ZcrvddPSyq57112/1z1ypOy6SUm/183JKbvuDTcYN2XV5Rpx+sE14vcH14jTD64Rpx914Bqxt2lrE/fQctfjYGzb0o9bR64Rt/xrk6u9y8/rV/Y55hphjGTG3TDDdc6+n/Nc2cflGnH64eEa4ZCMJONwOExZqnSPWKNGjeTj41Pqo7ZkZmbq1KlTat68udv25s2bKyMjw+M+GRkZHusXFhaWOvHI7NmzFRER4Xq0atWqet4AAABAPZCbX0YPdB1R2tpUqJjcgrr/Gdd3VRqa+MEHH7g9Lygo0NatW/X666/rscce0/jx46utgZVx+PBhtWjRQhs2bFCfPn1c22fNmqU33nhDe/bsKbFPx44dddttt2n69OmubevXr9ell16q9PR0RUdHl9gnPz/fNWukdHpoYqtWrRiaWNm6DDuqfF2GHZ3+b4YdVa0u14jT/801ovJ1uUac/u8Gdo3YfvCYbnr5K0mSsck1NFGSAgvy9O6EXurWqnHJ49byNeLHIzkaPv9LnfT/vb0BhU41+v/H/eieS9UuKtR9pwZ4jSg+T2cqHpooSa+N7S67vzx/xhLXiGLnMDSxSpN1jBgxosS2G264Qeeff76WLFlSa0HMbrfLx8enRO/XkSNHSvR6FYuOjvZY39fXV02bNvW4T0BAgAKKT/iZQkLcLxClqUidqtQ986JXnXXPvEhXZ90z/6dSnXUDAn7/B1Gddf39f/9HWVt1/fx+vzhVZ11f398vptVZ18en4t/hytRt1Khm6tpsNVNXqht1uUacxjWi8nW5RpzWwK4RoU2MW5g5U55foEKaRFbs+BZfIxw+zhLtzvf9/d9Qto9/2e1uINeIps391PP8lh57Dvt1aKpvM07ougtbVOwz5hpxWvG/+7J+GDzz0BU7asX06tVLq1atqs5DVoq/v7969OihTz/91G37p59+qr59+3rcp0+fPiXqf/LJJ+rZs6f8Kvo/KAAAAC9TX9d3asgLBFdGRLC/Zl93gS7t4N7x0K9DU93Wr632pmfX2c/YW1SpR8yTkydPav78+WrZsmV1HbJK7r//fv3xj39Uz5491adPH7388ss6cOCAJk6cKEmaPn26Dh06pEWLFkk6PUPiP//5T91///2aMGGCNm7cqFdffVXvvPNObb4NAACAWlW8vtO0lB1ad0avSV1f36k4QK7z0NNTlwNkbWjZJFhzR3bT/qO5yjpZoADfRtp6MEtLNh/Q4yO61tnP2FtUKYg1btxYtuKxsZKMMTp+/LiCg4P15ptvVlvjqmL06NE6evSoHn/8caWnp6tr165asWKF4uLiJEnp6ek6cOCAq37btm21YsUK3XfffXr++ecVGxur5557jjXEAABAg1cf13eqrwGytrRoHKzQAF/XZ3zdhS1kv7Qt58kCVZqsY+HChW5BrFGjRmrWrJl69eqlxo1LuaHPi7nWEStvrQAAAABYongh6voSIOE9KpoNqtQjNm7cuKq2CwAAAKhxEcEEL9RtFQ5iO3bsqPBBu3XrVqXGAAAAAEBDUOEgduGFF8pms6l4JOOZQxPPdqqCUzYCAAA0RMXD5rLzChQe5Cd7CL03aLga6r+HCgextLQ0139v3bpVU6ZM0YMPPuhaOHnjxo36+9//rqeeeqr6WwkAAOAlDmed1EMpO9zWb0qMt2vOyG6KjazEOlqAF2jI/x6qNFnHJZdcopkzZ2rYsGFu21esWKFHHnlE33zzTbU1sD5gsg4AAFARjlynJr2z1eMiuonxds0fk9AgegIAyXv/PdToZB07d+5U27ZtS2xv27atvvvuu6ocEgAAwOtl5jg9/tEpSetSM5WZ46yXf3gCVVHav4dgfx91axWpdEeefsw84bXDFasUxDp37qwnnnhCr776qgIDAyVJ+fn5euKJJ9S5c+dqbSAAAIC3yM4rKLP8eDnlgDfx9O8h2N9Hz41JUPL6NP3z8x9c271xuGKVgtiCBQt09dVXq1WrVurevbskafv27bLZbFq+fHm1NhAAAMBbhAf6lVkeVk454E0igvw06fIOSmgVqfzCIgX6+cgYo9fWp2n9D0fd6q5LzdS0lB31driiJ1UKYpdcconS0tL05ptvas+ePTLGaPTo0Ro7dqxCQkKqu40AAABewR7qr8R4u9aVck+MPdQ7/sAEKsLfp5G2Hjjm1vP11h29SoSwYt42fLdKQUySgoODdeedd1ZnWwAAALxaRLC/5ozspmkpO9zCWGK8XXNHdvOaPzCB8jhynZr+/s4SoctxsuEM361wEFu2bJmGDh0qPz8/LVu2rMy611xzzTk3DAAAwBvFRgZp/pgEZeY4dTyvQGGBfrKHet9EBEBZSpuoI8C3UZn7edPw3QoHsWuvvVYZGRmKiorStddeW2o9m83Ggs4AAABliAgmeKFhK23imq0Hs9SvQ1OPwxO9bfhuhYNYUVGRx/8GAAAAgMoobeKa175M03NjEtTIZiuxyLO3Dd+t8j1iZ8vKylJkZGR1HQ4AAACAlypt4ppc5ykt2XxAT9/YXTl5hV49fLfsQZilmDt3rpYsWeJ6fuONN6pJkyZq0aKFtm/fXm2NAwAAAOB9iieuSYy3u21PjLfr8RFd1Tw8UO2jQnVh68ZqHxXqdSFMkmzGGFPZndq1a6c333xTffv21aeffqpRo0ZpyZIlevfdd3XgwAF98sknNdHWOis7O1sRERFyOBwKDw+v7eYAAAAA9YIj1+l1E9dUNBtUaWhienq6WrVqJUlavny5Ro0apcGDB6tNmzbq1atX1VoMAAAAoEFpyBPXVGloYuPGjXXw4EFJ0sqVK3XFFVdIkowxzJgIAAAAAOWoUo/Y9ddfr7Fjxyo+Pl5Hjx7V0KFDJUnbtm1Thw4dqrWBAAAAAOBtqhTEnn32WbVp00YHDx7UU089pdDQUEmnhyzedddd1dpAAAAAAPA2VZqsA+6YrAMAAACAVPFsUKV7xCTpjTfe0KWXXqrY2Fjt379fkjRv3jx98MEHVT0kAAAAADQIVQpiL774ou6//34NHTpUWVlZrgk6IiMjNW/evOpsHwAAAACU4Mh1at+RHG09cEz7fs2RI9dZ202qlCrdIzZ//ny98soruvbaazVnzhzX9p49e2rKlCnV1jgAAAAAONvhrJN6KGWHvkjNdG1LjLdrzshuio0MqsWWVVyVesTS0tKUkJBQYntAQIBOnDhxzo0CAAAAAE8cuc4SIUyS1qVmalrKjnrTM1alINa2bVtt27atxPb//ve/6ty587m2CQAAAEA9YfUQwcwcZ4kQVmxdaqYyc+pHEKvS0MQHH3xQd999t/Ly8mSM0ebNm/XOO+/oySef1KuvvlrdbQQAAABQB9XGEMHsvIIyy4+XU15XVCmI3XbbbSosLNTUqVOVm5ursWPHqkWLFpo/f74uu+yy6m4jAAAAgDqmvCGC88ckKCLYv9pfNzzQr8zysHLK64oqT18/YcIE7d+/X0eOHFFGRoY2b96srVu3qkOHDtXZPgAAAAB1UG0NEbSH+isx3u6xLDHeLnto9Ye/mlCpIJaVlaWbb75ZzZo1U2xsrJ577jk1adJEzz//vDp06KBNmzbptddeq6m2AgAAAKgjamuIYESwv+aM7FYijCXG2zV3ZLca6YWrCZUamviXv/xF69atU1JSklauXKn77rtPK1euVF5enlasWKH+/fvXVDsBAAAA1CG1OUQwNjJI88ckKDPHqeN5BQoL9JM91L/ehDCpkkHso48+UnJysq644grddddd6tChgzp27MgizgAAAEADUzxEcJ2H4YlWDBGMCK5fwetslRqaePjwYXXp0kWS1K5dOwUGBuqOO+6okYYBAAAAqLu8ZYhgbalUj1hRUZH8/H7vYvTx8VFISEi1NwoAgIpy5DqVmeNUdl6BwoP8ZA+p37+QAkB94g1DBGtLpYKYMUbjxo1TQECAJCkvL08TJ04sEcaWLl1afS0EAKAUtbF+DQDAXX0fIlhbKhXEkpKS3J7fcsst1doYAAAqqrbWrwEAoDpUKoglJyfXVDsAAKiUiqxfQxADANRVVV7QGQCA2lRb69cAAFAdCGIAgHqpNtevAQDgXBHEAC/myHVq35EcbT1wTPt+zZEj11nbTQKqTfH6NZ5YsX4NAADnolL3iAGoP5hNDt6ueP2aaSk73BYTZf0aAEB9YDPGmNpuRH2XnZ2tiIgIORwOhYeH13ZzADlynZr0zlaPExkkxtuZTQ5epXgdMdavAQDUBRXNBvSIAV6I2eTQkLB+DQCgPuIeMcALMZscAABA3UaPGOCFmE0OAFBfFQ83zs4rUHiQn+wh9HrDO3lNj9hPP/2k8ePHq23btgoKClL79u01Y8YMOZ1lzxI3btw42Ww2t0fv3r0tajVQM5hNDgBQHx3OOqlJ72zVoGfW6roXNmjQ39fqnne26nDWydpuGlDtvCaI7dmzR0VFRXrppZf0v//9T88++6wWLFigv/zlL+Xue+WVVyo9Pd31WLFihQUtBmpO8WxyZ4cxZpMDANRVjlxnidl+pdP3Nk9L2cESLPA6XjM08corr9SVV17pet6uXTvt3btXL774op5++uky9w0ICFB0dHRNNxGwVGxkkOaPSWA2OQBAvcBEU2hovCaIeeJwONSkSZNy661Zs0ZRUVGKjIxU//79NWvWLEVFRZVaPz8/X/n5+a7n2dnZ1dJeoLoxmxwAoL5goik0NF4bxPbt26f58+fr73//e5n1hg4dqhtvvFFxcXFKS0vTI488ossvv1zffPONAgICPO4ze/ZsPfbYYzXRbAAAgAaJiaZKqumJS5gYpXbV+QWdZ86cWW7o2bJli3r27Ol6fvjwYfXv31/9+/fXv/71r0q9Xnp6uuLi4rR48WJdf/31Hut46hFr1aoVCzoDAABUkSPXqXve2ap1HoYnJsbbNX9MQoMKCYezTpa4Zy4x3q45I7spNjKozh+/Iavogs51PohlZmYqM9PzeOFibdq0UWBgoKTTIWzgwIHq1auXFi5cqEaNKj8fSXx8vO644w499NBDFapf0ZMNAABQ39VkL8rhrJOalrLDLYwVTzQV04DCgSPXqUnvbPV4z1x1hNKaPn5DV9FsUOeHJtrtdtntnqfhPtuhQ4c0cOBA9ejRQ8nJyVUKYUePHtXBgwcVExNT6X0BAAC8WU33ojDR1GmVnbiksuGYiVHqhjofxCrq8OHDGjBggFq3bq2nn35av/76q6vszBkRO3XqpNmzZ+u6665TTk6OZs6cqZEjRyomJkY//fST/vKXv8hut+u6666rjbcBAABQJ5U3vXx19aIw0VTlJi6pSjhmYpS6wWuC2CeffKIffvhBP/zwg1q2bOlWduboy71798rhcEiSfHx8tHPnTi1atEhZWVmKiYnRwIEDtWTJEoWFhVnafgAAgLqMXhTrVHTikqqGYyZGqRu8JoiNGzdO48aNK7femaEsKChIH3/8cQ22CgAAwDvQi2Ide6i/EuPtpU5cYg89Ha6qGo4renzUrMrfRAUAAIAGh14U60QE+2vOyG5KjHefJ6F44pLicFXVcFzR46NmeU2PGAAAAGoOvSjWqsjEJecSjpkYpfYRxAAAAFCu4l6U0qaX5w/46lfexCXnGo6ZGKV21fl1xOoD1hEDAAANRfFU6fSi1A1VWXutJteCgxetIwYAAIC6g16UuqWyQwxrei04VByTdQAAAAD1WESwv9pHherC1o3VPiq01BBW3nT3jlynFc3F/0cQAwAAABqAikx3D+sQxAAAAIAGgLXg6haCGAAAANAAsBZc3UIQAwAAABqA4unuPWEtOOsRxAAAAIAGoHgtuLPDGGvB1Q6mrwcAAAAaiMpOd4+aQxADAAAAGhDWgqsbGJoIAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIzJOgAAAADUeY5cpzJznMrOK1B4kJ/sIfV70hGCGAAAAIA67XDWST2UskNfpGa6tiXG2zVnZDfFRgbVYsuqjqGJAAAAAOosR66zRAiTpHWpmZqWskOOXGcttezcEMQAAAAA1FmZOc4SIazYutRMZeYQxAAAAACgWmXnFZRZfryc8rqKIAYAAACgzgoP9CuzPKyc8rqKIAYAAACgzrKH+isx3u6xLDHeLnto/Zw5kSAGAAAAoM6KCPbXnJHdSoSxxHi75o7sVm+nsGf6egAAAAB1WmxkkOaPSVBmjlPH8woUFugneyjriAEAAABAjYoIrt/B62wMTQQAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYr613QAAAAAAZXPkOpWZ41R2XoHCg/xkD/FXRLB/bTcL58CresTatGkjm83m9pg2bVqZ+xhjNHPmTMXGxiooKEgDBgzQ//73P4taDAAAAJTtcNZJTXpnqwY9s1bXvbBBg/6+Vve8s1WHs07WdtNwDrwqiEnS448/rvT0dNfjr3/9a5n1n3rqKT3zzDP65z//qS1btig6Olp/+MMfdPz4cYtaDAAAAHjmyHXqoZQd+iI10237utRMTUvZIUeus5ZahnPldUEsLCxM0dHRrkdoaGipdY0xmjdvnh5++GFdf/316tq1q15//XXl5ubq7bfftrDVAAAAQEmZOc4SIazYutRMZeYQxOorrwtic+fOVdOmTXXhhRdq1qxZcjpL/3KmpaUpIyNDgwcPdm0LCAhQ//79tWHDhlL3y8/PV3Z2ttsDAAAAqG7ZeQVllh8vpxx1l1dN1vHnP/9ZF110kRo3bqzNmzdr+vTpSktL07/+9S+P9TMyMiRJzZs3d9vevHlz7d+/v9TXmT17th577LHqazgAAADgQXigX5nlYeWUo+6q8z1iM2fOLDEBx9mPr7/+WpJ03333qX///urWrZvuuOMOLViwQK+++qqOHj1a5mvYbDa358aYEtvONH36dDkcDtfj4MGD5/5GAQAAgLPYQ/2VGG/3WJYYb5c9lJkT66s63yM2adIk3XTTTWXWadOmjcftvXv3liT98MMPatq0aYny6OhoSad7xmJiYlzbjxw5UqKX7EwBAQEKCAgor+kAAADAOYkI9teckd00LWWH1p1xr1hivF1zR3ZjCvt6rM4HMbvdLrvd868A5dm6daskuYWsM7Vt21bR0dH69NNPlZCQIElyOp1au3at5s6dW7UGAwAAANUoNjJI88ckKDPHqeN5BQoL9JM9lHXE6rs6H8QqauPGjdq0aZMGDhyoiIgIbdmyRffdd5+uueYatW7d2lWvU6dOmj17tq677jrZbDZNnjxZTz75pOLj4xUfH68nn3xSwcHBGjt2bC2+GwAA6gcWmQWsERHMvy1v4zVBLCAgQEuWLNFjjz2m/Px8xcXFacKECZo6dapbvb1798rhcLieT506VSdPntRdd92lY8eOqVevXvrkk08UFhZm9VsAAKBeOZx1ssT6Ronxds0Z2U2xkUG12DIAqPtsxhhT242o77KzsxURESGHw6Hw8PDabg4AADXOkevUpHe2elzfKDHervljEvj1HkCDVNFsUOdnTQQAAHUPi8wCwLkhiAEAgEpjkVkAODcEMQAAUGksMgsA54YgBgAAKo1FZgHg3BDEAABApRUvMnt2GGORWQCoGK+Zvh4AAFiLRWYBoOoIYgAAoMpYZBYAqoahiQAAAABgMXrEAAAA0GA5cp3KzHEqO69A4UF+sofQywtrEMQAAADQIB3OOqmHUna4LU6eGG/XnJHdFBsZVIstQ0PA0ESgDnPkOrXvSI62Hjimfb/myJHrrO0mAQDgFRy5zhIhTJLWpWZqWsoO/p+LGkePGFBH8SsdAAA1JzPHWSKEFVuXmqnMHCdDFFGj6BED6iB+pQMAoGZl5xWUWX68nHLgXBHEgDqoIr/SAQCAqgsP9CuzPKyccuBcEcSAOohf6QAAqFn2UH8lxts9liXG22UPZVgiahZBDKiD+JUOAICaFRHsrzkju5UIY4nxds0d2Y37w1DjmKwDqIOKf6Vb52F4Ir/SAQBQPWIjgzR/TIIyc5w6nlegsEA/2UNZRwzWoEcMqIP4lQ4AAGtEBPurfVSoLmzdWO2jQvl/LCxDjxhQR/ErHQAAgPciiAF1WEQwwQsAAMAbMTQRAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACL+dZ2AwAAANCwOXKdysxxKjuvQOFBfrKH+Csi2L+2mwXUKIIYAAAAas3hrJN6KGWHvkjNdG1LjLdrzshuio0MqsWWATWLoYkAAACoFY5cZ4kQJknrUjM1LWWHHLnOWmoZUPO8JoitWbNGNpvN42PLli2l7jdu3LgS9Xv37m1hywEAABqmzBxniRBWbF1qpjJzCGLwXl4zNLFv375KT0932/bII49o1apV6tmzZ5n7XnnllUpOTnY99/dnTDIAAEBNy84rKLP8eDnlQH3mNUHM399f0dHRrucFBQVatmyZJk2aJJvNVua+AQEBbvsCAACg5oUH+pVZHlZOOVCfec3QxLMtW7ZMmZmZGjduXLl116xZo6ioKHXs2FETJkzQkSNHyqyfn5+v7OxstwcAAAAqxx7qr8R4u8eyxHi77KGMUoL3shljTG03oiYMGzZMkrRixYoy6y1ZskShoaGKi4tTWlqaHnnkERUWFuqbb75RQECAx31mzpypxx57rMR2h8Oh8PDwc288AABAA3E466SmpezQurNmTZw7sptimDUR9VB2drYiIiLKzQZ1PoiVFnrOtGXLFrf7wH7++WfFxcXp3Xff1ciRIyv1eunp6YqLi9PixYt1/fXXe6yTn5+v/Px81/Ps7Gy1atWKIAYAAFAFxeuIHc8rUFign+yhrCOG+quiQazO3yM2adIk3XTTTWXWadOmjdvz5ORkNW3aVNdcc02lXy8mJkZxcXFKTU0ttU5AQECpvWUAAAConIhgghcanjofxOx2u+x2z2OHPTHGKDk5Wbfeeqv8/Cp/g+fRo0d18OBBxcTEVHpfAAAAAKgIr5us4/PPP1daWprGjx/vsbxTp056//33JUk5OTmaMmWKNm7cqJ9++klr1qzR1VdfLbvdruuuu87KZgMAAABoQOp8j1hlvfrqq+rbt686d+7ssXzv3r1yOBySJB8fH+3cuVOLFi1SVlaWYmJiNHDgQC1ZskRhYWFWNhsAAABAA1LnJ+uoDyp6Qx4AAAAA71bRbOB1QxMBAAAAoK4jiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAxghgAAAAAWIwgBgAAAAAWI4gBAAAAgMUIYgAAAABgMYIYAAAAAFiMIAYAAAAAFiOIAQAAAIDFCGIAAAAAYDGCGAAAAABYjCAGAAAAABYjiAEAAACAxQhiAAAAAGAx39puAKqPI9epzBynsvMKFB7kJ3uIvyKC/Wu7WQAAAADOQhDzEoezTuqhlB36IjXTtS0x3q45I7spNjKoFlsGAAAA4GwMTfQCjlxniRAmSetSMzUtZYccuc5aahkAAAAATwhiXiAzx1kihBVbl5qpzByCGAAAAFCXEMS8QHZeQZnlx8spBwAAAGAtgpgXCA/0K7M8rJxyAAAAANYiiHkBe6i/EuPtHssS4+2yhzJzIgAAAFCX1JsgNmvWLPXt21fBwcGKjIz0WOfAgQO6+uqrFRISIrvdrnvvvVdOZ9n3R+Xn5+uee+6R3W5XSEiIrrnmGv3888818A5qTkSwv+aM7FYijCXG2zV3ZDemsAcAAADqmHozfb3T6dSNN96oPn366NVXXy1RfurUKQ0fPlzNmjXTl19+qaNHjyopKUnGGM2fP7/U406ePFkffvihFi9erKZNm+qBBx7QVVddpW+++UY+Pj41+ZaqVWxkkOaPSVBmjlPH8woUFugneyjriAEAAAB1kc0YY2q7EZWxcOFCTZ48WVlZWW7b//vf/+qqq67SwYMHFRsbK0lavHixxo0bpyNHjig8PLzEsRwOh5o1a6Y33nhDo0ePliQdPnxYrVq10ooVKzRkyJAKtSk7O1sRERFyOBweXwcAAABAw1DRbFBvhiaWZ+PGjeratasrhEnSkCFDlJ+fr2+++cbjPt98840KCgo0ePBg17bY2Fh17dpVGzZsKPW18vPzlZ2d7fYAAAAAgIrymiCWkZGh5s2bu21r3Lix/P39lZGRUeo+/v7+aty4sdv25s2bl7qPJM2ePVsRERGuR6tWrc79DQAAAABoMGo1iM2cOVM2m63Mx9dff13h49lsthLbjDEet5elvH2mT58uh8Phehw8eLBSxwcAAADQsNXqZB2TJk3STTfdVGadNm3aVOhY0dHR+uqrr9y2HTt2TAUFBSV6ys7cx+l06tixY269YkeOHFHfvn1Lfa2AgAAFBARUqF0AAAAAcLZaDWJ2u112u+f1ryqrT58+mjVrltLT0xUTEyNJ+uSTTxQQEKAePXp43KdHjx7y8/PTp59+qlGjRkmS0tPTtWvXLj311FPV0i4AAAAAOFu9uUfswIED2rZtmw4cOKBTp05p27Zt2rZtm3JyciRJgwcPVpcuXfTHP/5RW7du1WeffaYpU6ZowoQJrtlKDh06pE6dOmnz5s2SpIiICI0fP14PPPCAPvvsM23dulW33HKLLrjgAl1xxRW19l4BAAAAeLd6s47Yo48+qtdff931PCEhQZK0evVqDRgwQD4+Pvroo4901113qV+/fgoKCtLYsWP19NNPu/YpKCjQ3r17lZub69r27LPPytfXV6NGjdLJkyc1aNAgLVy4sF6tIQYAAACgfql364jVRawjBgAAAEBqgOuIAQAAAEB9QRADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACL1Zt1xOqy4hUAsrOza7klAAAAAGpTcSYob5Uwglg1OH78uCSpVatWtdwSAAAAAHXB8ePHFRERUWo5CzpXg6KiIh0+fFhhYWGy2Wy13Zx6Lzs7W61atdLBgwdZILuacW5rBue15nBuaw7ntmZwXmsO57bmcG6rlzFGx48fV2xsrBo1Kv1OMHrEqkGjRo3UsmXL2m6G1wkPD+diUEM4tzWD81pzOLc1h3NbMzivNYdzW3M4t9WnrJ6wYkzWAQAAAAAWI4gBAAAAgMUIYqhzAgICNGPGDAUEBNR2U7wO57ZmcF5rDue25nBuawbnteZwbmsO57Z2MFkHAAAAAFiMHjEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQx1Kg2bdrIZrOVeNx9992S5LHMZrPp//7v/0o95sKFCz3uk5eXZ9XbqnWFhYX661//qrZt2yooKEjt2rXT448/rqKiIlcdY4xmzpyp2NhYBQUFacCAAfrf//5X7rFTUlLUpUsXBQQEqEuXLnr//fdr8q3UOeWd24KCAj300EO64IILFBISotjYWN166606fPhwmcfle1ux7+24ceNKnKPevXuXe+yG/L2tyHnlWlt1x48f1+TJkxUXF6egoCD17dtXW7ZscZVzra2ass4r19lzU953lutsHWKAGnTkyBGTnp7uenz66adGklm9erUxxriVpaenm9dee83YbDazb9++Uo+ZnJxswsPDS+zbkDzxxBOmadOmZvny5SYtLc289957JjQ01MybN89VZ86cOSYsLMykpKSYnTt3mtGjR5uYmBiTnZ1d6nE3bNhgfHx8zJNPPml2795tnnzySePr62s2bdpkxduqE8o7t1lZWeaKK64wS5YsMXv27DEbN240vXr1Mj169CjzuHxvK/a9TUpKMldeeaXbOTp69GiZx23o39uKnFeutVU3atQo06VLF7N27VqTmppqZsyYYcLDw83PP/9sjOFaW1VlnVeus+emvO8s19m6gyAGS/35z3827du3N0VFRR7LR4wYYS6//PIyj5GcnGwiIiJqoHX1x/Dhw83tt9/utu366683t9xyizHGmKKiIhMdHW3mzJnjKs/LyzMRERFmwYIFpR531KhR5sorr3TbNmTIEHPTTTdVY+vrtvLOrSebN282ksz+/ftLrcP3tmLnNikpyYwYMaJSx23o39uqfGe51lZMbm6u8fHxMcuXL3fb3r17d/Pwww9zra2i8s6rJ1xnK6Yi55brbN3B0ERYxul06s0339Ttt98um81WovyXX37RRx99pPHjx5d7rJycHMXFxally5a66qqrtHXr1ppocp116aWX6rPPPtP3338vSdq+fbu+/PJLDRs2TJKUlpamjIwMDR482LVPQECA+vfvrw0bNpR63I0bN7rtI0lDhgwpcx9vU9659cThcMhmsykyMrLMY/O9rdi5XbNmjaKiotSxY0dNmDBBR44cKfO4Df17W9nvLNfaiissLNSpU6cUGBjotj0oKEhffvkl19oqKu+8esJ1tmIqem65ztYRtZ0E0XAsWbLE+Pj4mEOHDnksnzt3rmncuLE5efJkmcfZuHGjeeONN8y2bdvMunXrzMiRI01QUJD5/vvva6LZdVJRUZGZNm2asdlsxtfX19hsNvPkk0+6ytevX28klTjXEyZMMIMHDy71uH5+fuatt95y2/bWW28Zf3//6n0DdVh55/ZsJ0+eND169DA333xzmcfle1uxc7t48WKzfPlys3PnTrNs2TLTvXt3c/7555u8vLxSj9vQv7eV/c5yra2cPn36mP79+5tDhw6ZwsJC88YbbxibzWY6duzItfYclHVez8Z1tnLKO7dcZ+sOghgsM3jwYHPVVVeVWn7eeeeZSZMmVfq4p06dMt27dzf33HPPuTSvXnnnnXdMy5YtzTvvvGN27NhhFi1aZJo0aWIWLlxojPk9iB0+fNhtvzvuuMMMGTKk1OP6+fmZt99+223bm2++aQICAqr/TdRR5Z3bMzmdTjNixAiTkJBgHA5HpV6H723Z57bY4cOHjZ+fn0lJSSm1TkP/3lb2vHKtrZwffvjBJCYmGknGx8fHXHzxxebmm282nTt35lp7Dso6r2fiOlt5FT23xbjO1h7fWuyMQwOyf/9+rVq1SkuXLvVY/sUXX2jv3r1asmRJpY/dqFEjXXzxxUpNTT3XZtYbDz74oKZNm6abbrpJknTBBRdo//79mj17tpKSkhQdHS1JysjIUExMjGu/I0eOqHnz5qUeNzo6WhkZGW7bytvH25R3bosVFBRo1KhRSktL0+eff67w8PBKvQ7f29LP7ZliYmIUFxdX5nlq6N/bypxXrrWV1759e61du1YnTpxQdna2YmJiNHr0aLVt25Zr7Tko67wW4zpbNRU5t2fiOlt7uEcMlkhOTlZUVJSGDx/usfzVV19Vjx491L1790of2xijbdu2uf1P0Nvl5uaqUSP3f74+Pj6u6aqL/0D49NNPXeVOp1Nr165V3759Sz1unz593PaRpE8++aTMfbxNeedW+v2Pg9TUVK1atUpNmzat9OvwvT3t7HN7tqNHj+rgwYNlnqeG/r2tzHnlWlt1ISEhiomJ0bFjx/Txxx9rxIgRXGurgafzKnGdrQ6lnduzcZ2tRbXbIYeG4NSpU6Z169bmoYce8ljucDhMcHCwefHFFz2W//GPfzTTpk1zPZ85c6ZZuXKl2bdvn9m6dau57bbbjK+vr/nqq69qpP11UVJSkmnRooVruuqlS5cau91upk6d6qozZ84cExERYZYuXWp27txpxowZU2JK5bPP7fr1642Pj4+ZM2eO2b17t5kzZ06Dm562vHNbUFBgrrnmGtOyZUuzbds2t+l/8/PzXcfhe1tSeef2+PHj5oEHHjAbNmwwaWlpZvXq1aZPnz6mRYsWfG/LUJHrgTFca6tq5cqV5r///a/58ccfzSeffGK6d+9uLrnkEuN0Oo0xXGurqqzzynX23JR1brnO1i0EMdS4jz/+2Egye/fu9Vj+0ksvmaCgIJOVleWxvH///iYpKcn1fPLkyaZ169bG39/fNGvWzAwePNhs2LChJppeZ2VnZ5s///nPpnXr1iYwMNC0a9fOPPzww27/gyoqKjIzZsww0dHRJiAgwCQmJpqdO3e6Hefsc2uMMe+9954577zzjJ+fn+nUqVOZY8a9UXnnNi0tzUjy+CheH88YvreelHduc3NzzeDBg02zZs2Mn5+fad26tUlKSjIHDhxwOw7fW3cVuR4Yw7W2qpYsWWLatWtn/P39TXR0tLn77rvdziHX2qop67xynT03ZZ1brrN1i80YY2qlKw4AAAAAGijuEQMAAAAAixHEAAAAAMBiBDEAAAAAsBhBDAAAAAAsRhADAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwCUMHPmTF144YWu5+PGjdO1115reTt++ukn2Ww2bdu2zfLXLs+AAQM0efJkS17LZrPpP//5jyWvVdd8/vnn6tSpk4qKiqp8jOXLlyshIeGcjgEA1Y0gBgD1xLhx42Sz2WSz2eTn56d27dppypQpOnHiRI2/9j/+8Q8tXLiwQnVrIzz98MMPuv3229W6dWsFBASoRYsWGjRokN566y0VFhZa1o5zdXYALpaenq6hQ4fW6GsvXLjQ9f2y2Wxq3ry5rr76av3vf/+r9HEiIyOrrV1Tp07Vww8/rEaNTv/JsnXrViUkJCg0NFTXXHONjh075qpbWFioiy66SFu2bHE7xlVXXSWbzaa333672toFAOeKIAYA9ciVV16p9PR0/fjjj3riiSf0wgsvaMqUKR7rFhQUVNvrRkREVOsf19Vp8+bNuuiii7R79249//zz2rVrl5YvX67bb79dCxYsKDNIVOc5qknR0dEKCAio8dcJDw9Xenq6Dh8+rI8++kgnTpzQ8OHD5XQ6a/y1PdmwYYNSU1N14403urbdcccduvzyy/Xtt98qKytLTz75pKvs6aef1qWXXqqLL764xLFuu+02zZ8/35J2A0BFEMQAoB4JCAhQdHS0WrVqpbFjx+rmm292DVkr7k157bXX1K5dOwUEBMgYI4fDoTvvvFNRUVEKDw/X5Zdfru3bt7sdd86cOWrevLnCwsI0fvx45eXluZWfPTSxqKhIc+fOVYcOHRQQEKDWrVtr1qxZkqS2bdtKkhISEmSz2TRgwADXfsnJyercubMCAwPVqVMnvfDCC26vs3nzZiUkJCgwMFA9e/bU1q1byzwfxhiNGzdOHTt21Pr163X11VcrPj5eCQkJuvnmm/XFF1+oW7dukn7vqXv33Xc1YMAABQYG6s0339TRo0c1ZswYtWzZUsHBwbrgggv0zjvvuL3OiRMndOuttyo0NFQxMTH6+9//XqItnoYPRkZGuvUkPvTQQ+rYsaOCg4PVrl07PfLII64wuHDhQj322GPavn27q1eqeN+zj71z505dfvnlCgoKUtOmTXXnnXcqJyfHVV78eT399NOKiYlR06ZNdffdd5cbPG02m6KjoxUTE6OePXvqvvvu0/79+7V3715XnWeeeUYXXHCBQkJC1KpVK911112u116zZo1uu+02ORwO13uYOXOmJMnpdGrq1Klq0aKFQkJC1KtXL61Zs6bM9ixevFiDBw9WYGCga9vu3bs1YcIEdezYUWPGjNF3330nSfrxxx/12muvub6HZ7vmmmu0efNm/fjjj2W+JgBYhSAGAPVYUFCQ2x/XP/zwg959912lpKS4hgYOHz5cGRkZWrFihb755htddNFFGjRokH777TdJ0rvvvqsZM2Zo1qxZ+vrrrxUTE1MiIJ1t+vTpmjt3rh555BF99913evvtt9W8eXNJp8OUJK1atUrp6elaunSpJOmVV17Rww8/rFmzZmn37t168skn9cgjj+j111+XdDrsXHXVVTrvvPP0zTffaObMmaX29hXbtm2bdu/erSlTpriGrp3NZrO5PX/ooYd07733avfu3RoyZIjy8vLUo0cPLV++XLt27dKdd96pP/7xj/rqq69c+zz44INavXq13n//fX3yySdas2aNvvnmmzLb5klYWJgWLlyo7777Tv/4xz/0yiuv6Nlnn5UkjR49Wg888IDOP/98paenKz09XaNHjy5xjNzcXF155ZVq3LixtmzZovfee0+rVq3SpEmT3OqtXr1a+/bt0+rVq/X6669r4cKFFR5eKklZWVmuoXx+fn6u7Y0aNdJzzz2nXbt26fXXX9fnn3+uqVOnSpL69u2refPmuXrW0tPTXZ/hbbfdpvXr12vx4sXasWOHbrzxRl155ZVKTU0ttQ3r1q1Tz5493bZ1795dn376qQoLC/XZZ5+5gvbEiRP11FNPKSwszOOx4uLiFBUVpS+++KLC5wAAapQBANQLSUlJZsSIEa7nX331lWnatKkZNWqUMcaYGTNmGD8/P3PkyBFXnc8++8yEh4ebvLw8t2O1b9/evPTSS8YYY/r06WMmTpzoVt6rVy/TvXt3j6+dnZ1tAgICzCuvvOKxnWlpaUaS2bp1q9v2Vq1ambfffttt29/+9jfTp08fY4wxL730kmnSpIk5ceKEq/zFF1/0eKxiixcvNpLMt99+69r2yy+/mJCQENfj+eefd2vXvHnzPB7rTMOGDTMPPPCAMcaY48ePG39/f7N48WJX+dGjR01QUJD585//7Nomybz//vtux4mIiDDJycmlvs5TTz1levTo4Xo+Y8YMt/Pu6dgvv/yyady4scnJyXGVf/TRR6ZRo0YmIyPDGHP684qLizOFhYWuOjfeeKMZPXp0qW1JTk42kkxISIgJDg42kowkc80115S6jzHGvPvuu6Zp06Zux4mIiHCr88MPPxibzWYOHTrktn3QoEFm+vTppR47IiLCLFq0yG3brl27TGJiomndurUZM2aMcTgc5vXXXzcjRowwP//8sxk8eLBp3769efjhh0scLyEhwcycObPM9wMAVvGttQQIAKi05cuXKzQ0VIWFhSooKNCIESPc7nuJi4tTs2bNXM+/+eYb5eTkqGnTpm7HOXnypPbt2yfp9FCviRMnupX36dNHq1ev9tiG3bt3Kz8/X4MGDapwu3/99VcdPHhQ48eP14QJE1zbCwsLFRER4Tpu9+7dFRwc7NaOijiz16tp06au3sABAwaUuL/p7B6WU6dOac6cOVqyZIkOHTqk/Px85efnKyQkRJK0b98+OZ1Ot7Y0adJE5513XoXadqZ///vfmjdvnn744Qfl5OSosLBQ4eHhlTpG8Xkqbp8k9evXT0VFRdq7d6+rZ/L888+Xj4+Pq05MTIx27txZ5rHDwsL07bffqrCwUGvXrtX//d//acGCBW51Vq9erSeffFLfffedsrOzVVhYqLy8PJ04ccKtTWf69ttvZYxRx44d3bbn5+eX+G6e6eTJk27DEovf19q1a13Pjx49qpkzZ2rdunW655571K9fPy1dulQXX3yxevXqpauvvtpVNygoSLm5uWWeAwCwCkEMAOqRgQMH6sUXX5Sfn59iY2PdhoxJKvGHcFFRkWJiYjzei1PVyTeCgoIqvU/xtOGvvPKKevXq5VZWHBaMMZU+bnx8vCRpz549rtkGfXx81KFDB0mSr2/J/82dfY7+/ve/69lnn9W8efNc9z5NnjzZFeAq2i6bzVai7pnDRjdt2qSbbrpJjz32mIYMGaKIiAgtXrzY4/1mZTHGlBhueWYbip393bDZbOVO396oUSPXuevUqZMyMjI0evRorVu3TpK0f/9+DRs2TBMnTtTf/vY3NWnSRF9++aXGjx9f5v1nRUVF8vHx0TfffOMWDiUpNDS01P3sdrvbrIie3HfffZo8ebJatmypNWvW6IknnlBISIiGDx+uNWvWuAWx3377ze2HCgCoTdwjBgD1SEhIiDp06KC4uLgSf2h7ctFFFykjI0O+vr7q0KGD28Nut0uSOnfurE2bNrntd/bzM8XHxysoKEifffaZx3J/f39Jp3uaijVv3lwtWrTQjz/+WKIdxZN7dOnSRdu3b9fJkycr1A7p9IQgnTp10tNPP13lNaK++OILjRgxQrfccou6d++udu3aud231KFDB/n5+bm15dixY/r+++/djtOsWTOlp6e7nqemprr1vqxfv15xcXF6+OGH1bNnT8XHx2v//v1ux/D393c7b5506dJF27Ztc1u2YP369WrUqFGJHqdzdd9992n79u16//33JUlff/21CgsL9fe//129e/dWx44ddfjw4XLfQ0JCgk6dOqUjR46U+Pyjo6NLff2EhATXZByefPbZZ9qzZ4/r/rhTp065AmFBQYFbO/Ly8rRv3z4lJCRU7iQAQA0hiAGAF7viiivUp08fXXvttfr444/1008/acOGDfrrX/+qr7/+WpL05z//Wa+99ppee+01ff/995oxY0aZU74HBgbqoYce0tSpU7Vo0SLt27dPmzZt0quvvipJioqKUlBQkFauXKlffvlFDodD0ulZHWfPnq1//OMf+v7777Vz504lJyfrmWeekSSNHTtWjRo10vjx4/Xdd99pxYoVevrpp8t8fzabTcnJydq7d6/69eunZcuWKTU1Vd99950WLFigX3/9tUQPzNk6dOigTz/9VBs2bNDu3bv1pz/9SRkZGa7y0NBQjR8/Xg8++KA+++wz7dq1S+PGjSsxOcjll1+uf/7zn/r222/19ddfa+LEiW5huUOHDjpw4IAWL16sffv26bnnnnMFnGJt2rRRWlqatm3bpszMTOXn55do780336zAwEAlJSVp165dWr16te655x798Y9/dA1LrC7h4eG64447NGPGDBlj1L59exUWFmr+/Pn68ccf9cYbb5QYutimTRvl5OTos88+U2ZmpnJzc9WxY0fdfPPNuvXWW7V06VKlpaVpy5Ytmjt3rlasWFHq6w8ZMkRffvmlx7KTJ0/q7rvv1ssvv+z6LPr166fnn39e27dvV0pKivr16+eqv2nTJgUEBFR4uCsA1LjavEENAFBxZ0/WcbbSJnrIzs4299xzj4mNjTV+fn6mVatW5uabbzYHDhxw1Zk1a5ax2+0mNDTUJCUlmalTp5Y6WYcxxpw6dco88cQTJi4uzvj5+ZnWrVubJ5980lX+yiuvmFatWplGjRqZ/v37u7a/9dZb5sILLzT+/v6mcePGJjEx0SxdutRVvnHjRtO9e3fj7+9vLrzwQpOSklLmZB3F9u7da5KSkkzLli2Nr6+viYiIMImJieall14yBQUFxpjSJxE5evSoGTFihAkNDTVRUVHmr3/9q7n11lvd3u/x48fNLbfcYoKDg03z5s3NU089Zfr37+82WcehQ4fM4MGDTUhIiImPjzcrVqwoMVnHgw8+aJo2bWpCQ0PN6NGjzbPPPus2sUVeXp4ZOXKkiYyMNJJc++qsiUB27NhhBg4caAIDA02TJk3MhAkTzPHjx0v9vIwx5s9//rPbZ3E2T5NsGGPM/v37ja+vr1myZIkxxphnnnnGxMTEmKCgIDNkyBCzaNEiI8kcO3bMtc/EiRNN06ZNjSQzY8YMY4wxTqfTPProo6ZNmzbGz8/PREdHm+uuu87s2LGj1Db99ttvJigoyOzZs6dE2bRp01wTqhRLTU01F198sQkPDzcTJ040p06dcpXdeeed5k9/+lOprwUAVrMZU4VB+QAAABaYOnWqHA6HXnrppSof49dff1WnTp309ddfu4bCAkBtY2giAACosx5++GHFxcWVe+9cWdLS0vTCCy8QwgDUKfSIAQAAAIDF6BEDAAAAAIsRxAAAAADAYgQxAAAAALAYQQwAAAAALEYQAwAAAACLEcQAAAAAwGIEMQAAAACwGEEMAAAAACxGEAMAAAAAi/0/hub1uT5vjY8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#residuals plot for the best_rf_model\n",
+    "residuals = y_test - y_pred_test\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "sns.scatterplot(x=y_pred_test, y=residuals)\n",
+    "plt.axhline(0, color='red', linestyle='--')\n",
+    "plt.title(\"Residuals vs Predicted Values\")\n",
+    "plt.xlabel(\"Predicted Graduation Rate (%)\")\n",
+    "plt.ylabel(\"Residuals\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 407,
+   "id": "bb022c3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1oAAAIhCAYAAABXMMsoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZpBJREFUeJzt3Xd4FOXi/v97gfRGWdIghBaqIlE8NA0gihQRFBHBEoooF6KiIuXrUVCR9vEoyhFRjwYRC3hARUBUlKKCCoogUg5iBBQiBCUhhGQT8vz+4JeFJT1OsrvJ+3Vdc+nOPDP77O5k2HufMjZjjBEAAAAAwDI13F0BAAAAAKhqCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgA8wsKFC2Wz2ZxLrVq1FBUVpVtuuUX79u2rsOedNm2abDZbqco2btxYw4cPr7C6lLU+7ta4cWOXzyw4OFgdO3bUokWLKuX588+ZX3/91bmue/fu6t69e5mPNWPGDL3//vuW1S3fr7/+KpvNpoULFxZZ5oEHHpDNZtOePXuKLPPII4/IZrPp+++/L/VzV8b5+nc98cQTatOmjfLy8pzrzj+nbDabQkND1aVLF7399tsF9r/wunH+MmHChGKfe/jw4bLZbAoJCVFGRkaB7QcOHFCNGjVks9k0bdq0v/1a861fv142m03r168v876FnfO33367Bg4caFn9AFiHoAXAoyQlJWnz5s1au3atxo0bpxUrVuiKK67QX3/9VSHPd+edd2rz5s0VcuzqoGvXrtq8ebM2b97s/BKYmJioF1980S31mT9/vubPn1/m/SoqaJXGqFGjJEmvvfZaodvz8vK0aNEitW/fXpdeemllVq1CHT58WHPmzNETTzyhGjVcv47cdNNN2rx5szZt2qQFCxYoPT1dw4YN01tvvVXosfKvG+cv9913X4l18PHxUW5urpYsWVLoMUNCQsr34irRtGnTtGrVKn3++efurgqACxC0AHiUiy66SJ06dVL37t31yCOPaPLkyTp69GiFfQlu2LChOnXqVCHHrg5q166tTp06qVOnTrrpppu0Zs0ahYaG6plnnilynzNnzig7O7tC6tOmTRu1adOmQo5dUS666CL94x//0BtvvKHc3NwC2z/55BP99ttvzkBWVTz33HOqXbu2brzxxgLbIiIi1KlTJ3Xu3FnDhg3TqlWrJEkvvfRSocfKv26cvzRq1KjEOvj6+mrgwIEFQq4xRgsXLtSQIUPK8coqV7NmzdS7d2/NmjXL3VUBcAGCFgCP1qFDB0nSH3/84bJ+69atuv7661W3bl35+/srPj5eS5cudSmTmZmpCRMmqEmTJvL391fdunXVoUMHly5IhXXVy8nJ0cSJExUZGanAwEBdccUV+vbbbwvUrahufoV171myZIl69eqlqKgoBQQEqHXr1po8ebJOnTpV4nvw+eefq3v37qpXr54CAgLUqFEjDRo0SJmZmUXuM3DgQMXGxrp0ycrXsWNHl5aRd999Vx07dlRYWJgCAwPVtGlTjRw5ssR6FaZ27dpq2bKlDhw4IOlc17k5c+Zo+vTpatKkifz8/LRu3TpJpfscJenrr79W165d5e/vr+joaE2ZMkU5OTkFyhXWdTA7O1tPPPGEWrduLX9/f9WrV089evTQpk2bJJ3tqnbq1Cm9/vrrzm5n5x8jJSVFd999txo2bChfX181adJEjz/+eIFQdPjwYd18880KCQlRWFiYhgwZopSUlFK9b6NGjVJKSoo++uijAtuSkpLk5+enW2+9VVlZWXrooYfUvn17hYWFqW7duurcubM++OCDEp+jsPNSKror29q1a9WzZ0+FhoYqMDBQXbt21WeffeZS5tixY7rrrrsUExMjPz8/1a9fX127dtXatWuLrYvD4dCrr76qYcOGFWjNKkxsbKzq169f4DpghZEjR2rTpk3au3evc93atWt14MABjRgxotB9du7cqQEDBqhOnTry9/dX+/bt9frrrxcot2fPHvXu3VuBgYGy2+0aM2aMTp48WegxS/N+F+X222/X2rVrtX///lKVB1A5CFoAPFpycrIkqUWLFs5169atU9euXXXixAktWLBAH3zwgdq3b68hQ4a4jIV58MEH9eKLL+q+++7TmjVr9MYbb2jw4ME6fvx4sc85evRoPf3007rjjjv0wQcfaNCgQbrxxhv/VvfFffv2qW/fvnr11Ve1Zs0ajR8/XkuXLlX//v2L3e/XX39Vv3795Ovrq9dee01r1qzRrFmzFBQUJIfDUeR+I0eO1MGDBwt0J9qzZ4++/fZb5xfIzZs3a8iQIWratKneeecdrVq1So899lihLSulkZOTowMHDqh+/fou659//nl9/vnnevrpp/XRRx+pVatWpf4cd+3apZ49e+rEiRNauHChFixYoG3btmn69Okl1ic3N1d9+vTRk08+qeuuu07vvfeeFi5cqC5duujgwYPO9yAgIEB9+/Z1djvL736YkpKif/zjH/r444/12GOP6aOPPtKoUaM0c+ZMjR492vk8p0+f1tVXX61PPvlEM2fO1LvvvqvIyMhSt4gMHTpUgYGBBVpW/vrrL33wwQe64YYbVKdOHWVnZ+vPP//UhAkT9P777+vtt9/WFVdcoRtvvNHSsXGLFy9Wr169FBoaqtdff11Lly5V3bp1de2117p8+b/99tv1/vvv67HHHtMnn3yi//znP7r66qtL/Bv75ptvdPz4cfXo0aNU9UlLS9Off/7pch0435kzZ5Sbm+uylNbVV1+t2NhYl/f+1VdfVUJCguLi4gqU37t3r7p06aKffvpJzz//vJYvX642bdpo+PDhmjNnjrPcH3/8oW7dumnnzp2aP3++3njjDWVkZGjcuHEFjlna97so3bt3lzFGq1evLvXrBlAJDAB4gKSkJCPJfP311yYnJ8ecPHnSrFmzxkRGRpqEhASTk5PjLNuqVSsTHx/vss4YY6677joTFRVlzpw5Y4wx5qKLLjIDBw4s9nmnTp1qzr8U7t6920gyDzzwgEu5N99800gyiYmJRe574WtJTk4u9Dnz8vJMTk6O2bBhg5Fktm/fXuQx//vf/xpJ5ocffij2dVwoJyfHREREmGHDhrmsnzhxovH19TWpqanGGGOefvppI8mcOHGiTMc3xpjY2FjTt29fk5OTY3JyckxycrJJTEw0kszDDz9sjDEmOTnZSDLNmjUzDofDZf/Sfo5DhgwxAQEBJiUlxVkmNzfXtGrVqsD73K1bN9OtWzfn40WLFhlJ5pVXXin2tQQFBbl8tvnuvvtuExwcbA4cOOCyPv99++mnn4wxxrz44otGkvnggw9cyo0ePdpIMklJScU+vzHGJCYmGh8fH/PHH384182bN89IMp9++mmh++Tm5pqcnBwzatQoEx8f77ItNjbW5TUVdV6uW7fOSDLr1q0zxhhz6tQpU7duXdO/f3+XcmfOnDGXXHKJ+cc//uFcFxwcbMaPH1/ia7vQ7NmzjSSXzzSfJDN27FiTk5NjHA6H+d///meuv/56ExISYrZu3epSNv81FbZceF5dKDEx0QQFBRljzv7dRUZGmpycHHP8+HHj5+dnFi5caI4dO2YkmalTpzr3u+WWW4yfn585ePCgy/H69OljAgMDnX9LkyZNMjabrcDf7jXXXFPu97u4a0uDBg3MkCFDin3NACoXLVoAPEqnTp3k4+OjkJAQ9e7dW3Xq1NEHH3ygWrVqSZJ+/vln7dmzR7feeqskufyC3bdvXx05csTZBegf//iHPvroI02ePFnr16/X6dOnS3z+/C5t+cfPd/PNNzvrUB6//PKLhg0bpsjISNWsWVM+Pj7q1q2bJGn37t1F7te+fXv5+vrqrrvu0uuvv65ffvmlVM9Xq1Yt3XbbbVq+fLnS0tIknf3V/4033tCAAQNUr149SdLll1/ufH1Lly7V77//XqbXtXr1avn4+MjHx0dNmjTR0qVLde+99xZobbr++uvl4+PjfFyWz3HdunXq2bOnIiIinPvXrFmzVK1FH330kfz9/cvdFXLlypXq0aOHoqOjXerYp08fSdKGDRucdQwJCdH111/vsv+wYcNK/VyjRo1STk6O3njjDee6pKQkxcbGqmfPns517777rrp27arg4GDVqlVLPj4+evXVV4s9j8pi06ZN+vPPP5WYmOjymvPy8tS7d29t2bLF2eX1H//4hxYuXKjp06fr66+/LrQ7Z2EOHz4sm80mu91e6Pb58+fLx8dHvr6+atGihT766CO9/fbbuuyyywotv2jRIm3ZssVlKcvf64gRI/THH3/oo48+0ptvvilfX18NHjy40LKff/65evbsqZiYGJf1w4cPV2ZmpnNynXXr1qlt27a65JJLXMpdeE6U5f0uTnh4eJn/fgFULIIWAI+S/4Xp888/1913363du3dr6NChzu35YzQmTJjg/IKfv4wdO1aSlJqaKulsd7VJkybp/fffV48ePVS3bl0NHDiw2Oni87s8RUZGuqyvVauWM5yUVUZGhq688kp98803mj59utavX68tW7Zo+fLlklRsAGzWrJnWrl2r8PBw3XPPPWrWrJmaNWum5557rsTnHTlypLKysvTOO+9Ikj7++GMdOXLEZdxJQkKC3n//feXm5uqOO+5Qw4YNddFFFxU6lXZhrrjiCm3ZskVbt27Vrl27dOLECT3//PPy9fV1KRcVFeXyuCyf4/Hjxwt8HlLBz6gwx44dU3R0dKnGARXmjz/+0Icffligjm3bti1Qx/ODYFnqmO/KK69UixYtlJSUJEnasWOHvv/+e40YMcI5FnD58uW6+eab1aBBAy1evFibN2/Wli1bnJ+1FfI/m5tuuqnA6549e7aMMfrzzz8lnR17mJiYqP/85z/q3Lmz6tatqzvuuKPEsWmnT5+Wj4+PatasWej2m2++WVu2bNGmTZv00ksvKSQkpNhbPbRu3VodOnRwWcoiP8y+9tpreu2113TLLbcoMDCw0LLHjx8vcD5LUnR0tHN7/n9Lc96W5f0ujr+/f6l+TAJQecr/8ywAVID8L0yS1KNHD505c0b/+c9/9N///lc33XST8xfwKVOmFDpbmSS1bNlSkhQUFKTHH39cjz/+uPPX6smTJ6t///5F3rMoP0ylpKSoQYMGzvW5ubkFxp34+/tLOjvZgp+fn3N9/pfvfJ9//rkOHz6s9evXO1uxJOnEiRMlvh/S2S/gV155pc6cOaOtW7dq3rx5Gj9+vCIiInTLLbcUuV+bNm30j3/8Q0lJSbr77ruVlJSk6Oho9erVy6XcgAEDNGDAAGVnZ+vrr7/WzJkzNWzYMDVu3FidO3cutm5hYWGl+lJ74aQhZfkc69WrV+gX99JMNFG/fn19+eWXysvLK1fYstvtateunZ566qlCt+d/ua5Xr16hE6aUdjKMfCNHjtTkyZP17bff6q233lKNGjVc7oW1ePFiNWnSREuWLHF5T0szi+P55+v5Ljxf8z+befPmFTkjZ36otNvtmjt3rubOnauDBw9qxYoVzplC16xZU2Rd7Ha7HA6HTp06paCgoALb69ev7zyvOnfurNatW6tbt2564IEHtHLlyhJfa3mMHDlSt912m/Ly8oq9PUG9evV05MiRAusPHz4s6dz7V9rztizvd3H+/PNPNW7cuMRyACoPLVoAPNqcOXNUp04dPfbYY8rLy1PLli0VFxen7du3F/gFO38p7N43ERERGj58uIYOHaq9e/cWOWNf/mxzb775psv6pUuXFhhgn/+lZseOHS7rP/zwQ5fH+V+Izw9jUtFTVRelZs2a6tixo1544QVJKtXNa0eMGKFvvvlGX375pT788EMlJiYW2Yrg5+enbt26afbs2ZKkbdu2lal+ZVGWz7FHjx767LPPXGacO3PmTKH3PrpQnz59lJWVVewNg6Wzr72w1oDrrrtOO3fuVLNmzQqtY37Q6tGjh06ePKkVK1a47F/UfZ+KkpiYqFq1aumll17Sm2++qZ49eyo2Nta53WazydfX1yVkpaSklGrWwaLO1wvr3LVrV9WuXVu7du0q8rO5sMVSkho1aqRx48bpmmuuKfHcbNWqlSSVepa8K6+8UnfccYdWrVpVYfe9u+GGG3TDDTdo5MiRxd7yoWfPns4fT863aNEiBQYGOvft0aOHfvrpJ23fvt2l3IXnRHnf7/Pl5ubq0KFDXndrA6Cqo0ULgEerU6eOpkyZookTJ+qtt97Sbbfdppdeekl9+vTRtddeq+HDh6tBgwb6888/tXv3bn3//fd69913JZ2dxvy6665Tu3btVKdOHe3evVtvvPGGOnfuXGS3oNatW+u2227T3Llz5ePjo6uvvlo7d+7U008/rdDQUJeyffv2Vd26dTVq1Cg98cQTqlWrlhYuXKhDhw65lOvSpYvq1KmjMWPGaOrUqfLx8dGbb75Z4AtYYRYsWKDPP/9c/fr1U6NGjZSVleWcHe3qq68ucf+hQ4fqwQcf1NChQ5Wdne3SOiJJjz32mH777Tf17NlTDRs21IkTJ/Tcc8+5jCGrKKX9HP/5z39qxYoVuuqqq/TYY48pMDBQL7zwQqnGrQwdOlRJSUkaM2aM9u7dqx49eigvL0/ffPONWrdu7WwRvPjii7V+/Xp9+OGHioqKUkhIiFq2bKknnnhCn376qbp06aL77rtPLVu2VFZWln799VetXr1aCxYsUMOGDXXHHXfo2Wef1R133KGnnnpKcXFxWr16tT7++OMyvSeRkZHq27evkpKSZIwpcO+s6667TsuXL9fYsWN100036dChQ3ryyScVFRVVbJdY6ex4vJYtW2rChAnKzc1VnTp19N577+nLL790KRccHKx58+YpMTFRf/75p2666SaFh4fr2LFj2r59u44dO6YXX3xRaWlp6tGjh4YNG6ZWrVopJCREW7Zs0Zo1a4pspcyX/4PG119/rXbt2pXqvXnyySe1ZMkSPfrooyVOH18e/v7++u9//1tiualTpzrH7j322GOqW7eu3nzzTa1atUpz5sxRWFiYJGn8+PF67bXX1K9fP02fPl0RERF68803C7Sml/b9Ls6OHTuUmZlZ6lkcAVQSN0/GAQDGmHOzaW3ZsqXAttOnT5tGjRqZuLg4k5uba4wxZvv27ebmm2824eHhxsfHx0RGRpqrrrrKLFiwwLnf5MmTTYcOHUydOnWMn5+fadq0qXnggQecM+4ZU/jMgdnZ2eahhx4y4eHhxt/f33Tq1Mls3ry5wCxuxhjz7bffmi5dupigoCDToEEDM3XqVPOf//ynwMxgmzZtMp07dzaBgYGmfv365s477zTff/99gRnpLqzP5s2bzQ033GBiY2ONn5+fqVevnunWrZtZsWJFqd/bYcOGGUmma9euBbatXLnS9OnTxzRo0MD4+vqa8PBw07dvX/PFF1+UeNzY2FjTr1+/Ysvkzzr4f//3f4VuL83naIwxX331lenUqZPx8/MzkZGR5uGHHzYvv/xyibMOGnP2/HnsscdMXFyc8fX1NfXq1TNXXXWV2bRpk7PMDz/8YLp27WoCAwONJJdjHDt2zNx3332mSZMmxsfHx9StW9dcdtll5pFHHjEZGRnOcr/99psZNGiQCQ4ONiEhIWbQoEFm06ZNpZ51MN8HH3xgJJm6deuarKysAttnzZplGjdubPz8/Ezr1q3NK6+8Uuh5XNj5+r///c/06tXLhIaGmvr165t7773XrFq1ymUWvHwbNmww/fr1M3Xr1jU+Pj6mQYMGpl+/fubdd981xhiTlZVlxowZY9q1a2dCQ0NNQECAadmypZk6dao5depUia/zyiuvNH379i2wXpK55557Ct3n4YcfNpLMhg0bjDHFXzdKcv6sg0UpbNZBY4z58ccfTf/+/U1YWJjx9fU1l1xySaGf8a5du8w111xj/P39Td26dc2oUaOcn29Z3+/zX++Fsw4++uijxm63F3q+AHAfmzHGVHK2AwAA1dyyZcs0ZMgQHThwwGU8JMrmzJkzat68uYYNG1bkWEIA7sEYLQAAUOluvPFGXX755Zo5c6a7q+LVFi9erIyMDD388MPurgqACxC0AABApbPZbHrllVcUHR2tvLw8d1fHa+Xl5enNN99U7dq13V0VABeg6yAAAAAAWIwWLQAAAACwGEELAAAAACxG0AIAAAAAi3HD4hLk5eXp8OHDCgkJkc1mc3d1AAAAALiJMUYnT55UdHS0atQooc3KrXfxOs+GDRvMddddZ6Kioowk895777lsz8vLM1OnTjVRUVHG39/fdOvWzezcubPE4/73v/81rVu3Nr6+vqZ169Zm+fLlZarXoUOHjCQWFhYWFhYWFhYWFhYjyRw6dKjEHOExLVqnTp3SJZdcohEjRmjQoEEFts+ZM0fPPPOMFi5cqBYtWmj69Om65pprtHfvXoWEhBR6zM2bN2vIkCF68skndcMNN+i9997TzTffrC+//FIdO3YsVb3yj33o0CGFhoaW/wUCAAAA8Grp6emKiYkpMn+czyOnd7fZbHrvvfc0cOBASZIxRtHR0Ro/frwmTZokScrOzlZERIRmz56tu+++u9DjDBkyROnp6froo4+c63r37q06dero7bffLlVd0tPTFRYWprS0NIIWAAAAUI2VJRt4xWQYycnJSklJUa9evZzr/Pz81K1bN23atKnI/TZv3uyyjyRde+21xe6TnZ2t9PR0lwUAAAAAysIrglZKSookKSIiwmV9RESEc1tR+5V1n5kzZyosLMy5xMTE/I2aAwAAAKiOvCJo5btw1j9jTIkzAZZ1nylTpigtLc25HDp0qPwVBgAAAFAtecxkGMWJjIyUdLaFKioqyrn+6NGjBVqsLtzvwtarkvbx8/OTn5/f36wxAAAAgOrMK1q0mjRposjISH366afOdQ6HQxs2bFCXLl2K3K9z584u+0jSJ598Uuw+AAAAAPB3eUyLVkZGhn7++Wfn4+TkZP3www+qW7euGjVqpPHjx2vGjBmKi4tTXFycZsyYocDAQA0bNsy5zx133KEGDRpo5syZkqT7779fCQkJmj17tgYMGKAPPvhAa9eu1Zdfflnprw8AAABA9eExQWvr1q3q0aOH8/GDDz4oSUpMTNTChQs1ceJEnT59WmPHjtVff/2ljh076pNPPnGZw/7gwYMud2ju0qWL3nnnHf3zn//Uo48+qmbNmmnJkiWlvocWAAAAAJSHR95Hy5NwHy0AAAAAUhW8jxYAAAAAeBOCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWMxj7qMFAICnS8t0KDXDofSsHIUG+Mge5KuwQF93VwsA4IEIWgAAlMLhE6c1adkOfbEv1bkuIc6uWYPaKbp2gBtrBgDwRHQdBACgBGmZjgIhS5I27kvV5GU7lJbpcFPNAACeiqAFAEAJUjMcBUJWvo37UpWaQdACALgiaAEAUIL0rJxit58sYTsAoPohaAEAUIJQf59it4eUsB0AUP0QtAAAKIE92FcJcfZCtyXE2WUPZuZBAIArghYAACUIC/TVrEHtCoSthDi7Zg9qxxTvAIACmN4dAIBSiK4doHlD45Wa4dDJrByF+PvIHsx9tAAAhSNoAQBQSmGBBCsAQOnQdRAAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiXhO0GjduLJvNVmC55557Ci2/fv36Qsvv2bOnkmsOAAAAoLqp5e4KlNaWLVt05swZ5+OdO3fqmmuu0eDBg4vdb+/evQoNDXU+rl+/foXVEQAAAAAkLwpaFwakWbNmqVmzZurWrVux+4WHh6t27doVWDMAAAAAcOU1XQfP53A4tHjxYo0cOVI2m63YsvHx8YqKilLPnj21bt26Eo+dnZ2t9PR0lwUAAAAAysIrg9b777+vEydOaPjw4UWWiYqK0ssvv6xly5Zp+fLlatmypXr27KmNGzcWe+yZM2cqLCzMucTExFhcewAAAABVnc0YY9xdibK69tpr5evrqw8//LBM+/Xv3182m00rVqwoskx2drays7Odj9PT0xUTE6O0tDSXsV4AAAAAqpf09HSFhYWVKht4zRitfAcOHNDatWu1fPnyMu/bqVMnLV68uNgyfn5+8vPzK2/1AAAAAMD7ug4mJSUpPDxc/fr1K/O+27ZtU1RUVAXUCgAAAADO8aoWrby8PCUlJSkxMVG1arlWfcqUKfr999+1aNEiSdLcuXPVuHFjtW3b1jl5xrJly7Rs2TJ3VB0AAKDCpWU6lJrhUHpWjkIDfGQP8lVYoK+7qwVUS14VtNauXauDBw9q5MiRBbYdOXJEBw8edD52OByaMGGCfv/9dwUEBKht27ZatWqV+vbtW5lVBgAAqBSHT5zWpGU79MW+VOe6hDi7Zg1qp+jaAW6sGVA9eeVkGJWpLAPeAAAA3CEt06Fxb29zCVn5EuLsmjc0npYtwAJlyQZeN0YLAAAArlIzHIWGLEnauC9VqRmOSq4RAIIWAACAl0vPyil2+8kStgOwHkELAADAy4X6+xS7PaSE7QCsR9ACAADwcvZgXyXE2QvdlhBnlz2Y8VlAZSNoAQAAeLmwQF/NGtSuQNhKiLNr9qB2TIQBuIFXTe8OAACAwkXXDtC8ofFKzXDoZFaOQvx9ZA/mPlqAuxC0AAAAqoiwQIIV4CnoOggAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABar5e4KAACqn7RMh1IzHErPylFogI/sQb4KC/R1d7UAALAMQQsAUKkOnzitSct26It9qc51CXF2zRrUTtG1A9xYMwAArEPXQQBApUnLdBQIWZK0cV+qJi/bobRMh5tqBgCAtQhaAIBKk5rhKBCy8m3cl6rUDIIWAKBqIGgBACpNelZOsdtPlrAdAABvQdACAFSaUH+fYreHlLAdAABvQdACAFQae7CvEuLshW5LiLPLHszMgwCAqoGgBQCoNGGBvpo1qF2BsJUQZ9fsQe2Y4h0AUGUwvTsAoFJF1w7QvKHxSs1w6GRWjkL8fWQP5j5aAICqhaAFAKh0YYEEKwBA1UbXQQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwmNcErWnTpslms7kskZGRxe6zYcMGXXbZZfL391fTpk21YMGCSqotAAAAgOqslrsrUBZt27bV2rVrnY9r1qxZZNnk5GT17dtXo0eP1uLFi/XVV19p7Nixql+/vgYNGlQZ1QUAAABQTXlV0KpVq1aJrVj5FixYoEaNGmnu3LmSpNatW2vr1q16+umnCVoAAAAAKpTXdB2UpH379ik6OlpNmjTRLbfcol9++aXIsps3b1avXr1c1l177bXaunWrcnJyitwvOztb6enpLgsAAAAAlIXXBK2OHTtq0aJF+vjjj/XKK68oJSVFXbp00fHjxwstn5KSooiICJd1ERERys3NVWpqapHPM3PmTIWFhTmXmJgYS18HAAAAUBnSMh3afzRD2w7+pf3HMpSW6XB3laoVr+k62KdPH+f/X3zxxercubOaNWum119/XQ8++GCh+9hsNpfHxphC159vypQpLsdLT08nbAEAAMCrHD5xWpOW7dAX+841MCTE2TVrUDtF1w5wY82qD69p0bpQUFCQLr74Yu3bt6/Q7ZGRkUpJSXFZd/ToUdWqVUv16tUr8rh+fn4KDQ11WQAAAABvkZbpKBCyJGnjvlRNXraDlq1K4rVBKzs7W7t371ZUVFSh2zt37qxPP/3UZd0nn3yiDh06yMfHpzKqCAAAAFS61AxHgZCVb+O+VKVmELQqg9cErQkTJmjDhg1KTk7WN998o5tuuknp6elKTEyUdLbL3x133OEsP2bMGB04cEAPPvigdu/erddee02vvvqqJkyY4K6XAAAAAFS49KyiJ36TpJMlbIc1vGaM1m+//aahQ4cqNTVV9evXV6dOnfT1118rNjZWknTkyBEdPHjQWb5JkyZavXq1HnjgAb3wwguKjo7W888/z9TuAAAAqNJC/YvvvRVSwnZYw2byZ4hAodLT0xUWFqa0tDTGawEAAMDjpWU6dO/b27SxkO6DCXF2zRsar7BAXzfUzPuVJRt4TddBAAAKw/TFAOAqLNBXswa1U0Kc3WV9Qpxdswe1I2RVEq/pOggAwIWYvhgAChddO0DzhsYrNcOhk1k5CvH3kT3Yl5BViWjRAgB4JaYvBoDihQX6qll4sNo3qqNm4cGErEpG0AIAeCWmLwYAeDKCFgDAKzF9MQDAkxG0AABeiemLAQCejKAFAPBK9mDfAjNq5UuIs8sezFgEAID7ELQAAF6J6YsBAJ6M6d0BAF6L6YsBAJ6KoAUA8GphgQQrAIDnoesgAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFjMa4LWzJkzdfnllyskJETh4eEaOHCg9u7dW+w+69evl81mK7Ds2bOnkmoNAAAAoDqq5e4KlNaGDRt0zz336PLLL1dubq4eeeQR9erVS7t27VJQUFCx++7du1ehoaHOx/Xr16/o6gIAAABeJy3TodQMh9KzchQa4CN7kK/CAn3dXS2v5DVBa82aNS6Pk5KSFB4eru+++04JCQnF7hseHq7atWtXYO0AAAAA73b4xGlNWrZDX+xLda5LiLNr1qB2iq4d4MaaeSev6Tp4obS0NElS3bp1SywbHx+vqKgo9ezZU+vWrSu2bHZ2ttLT010WAAAAoCpLy3QUCFmStHFfqiYv26G0TIebaua9vDJoGWP04IMP6oorrtBFF11UZLmoqCi9/PLLWrZsmZYvX66WLVuqZ8+e2rhxY5H7zJw5U2FhYc4lJiamIl4CAAAA4DFSMxwFQla+jftSlZpB0CormzHGuLsSZXXPPfdo1apV+vLLL9WwYcMy7du/f3/ZbDatWLGi0O3Z2dnKzs52Pk5PT1dMTIzS0tJcxnkBAABrMCYEcL9tB//SDfM3Fbn9/bFd1L5RnUqskWdKT09XWFhYqbKB14zRynfvvfdqxYoV2rhxY5lDliR16tRJixcvLnK7n5+f/Pz8/k4VAQBAKTEmBPAMof4+xW4PKWE7CvKaroPGGI0bN07Lly/X559/riZNmpTrONu2bVNUVJTFtQMAAGXFmBDAc9iDfZUQZy90W0KcXfZgWpnLymtatO655x699dZb+uCDDxQSEqKUlBRJUlhYmAICzv7iNWXKFP3+++9atGiRJGnu3Llq3Lix2rZtK4fDocWLF2vZsmVatmyZ214HAAA4qzRjQqpKF0K6R8LThQX6atagdpq8bIc2XtDCPHtQO87XcvCaoPXiiy9Kkrp37+6yPikpScOHD5ckHTlyRAcPHnRuczgcmjBhgn7//XcFBASobdu2WrVqlfr27VtZ1QYAAEVIz8opdvvJErZ7C7pHwltE1w7QvKHxSs1w6GRWjkL8fWQP5keB8vLKyTAqU1kGvAEAgNLbfzRDPZ/ZUOT2zx7spmbhwZVYI+ulZTo07u1thbbcJcTZNW9oPF9iAS9SlmzgNWO0AMDbpGU6tP9ohrYd/Ev7j2Uw3gS4QHUYE8KU2UD15TVdBwHAm9BVCChZdRgTUl26RwIoiKAFABYraSY1ugoB51T1MSFMmQ1PwYQslY+gBQAWq04zqQFWCAusul/48rtHbixijFZV6B4Jz0cvC/dgjBYAWIyuQgDy5XePvHAsWlXqHgnP5sn3q6vqY5lp0QIAi9FVCMD5qnr3SHg2T+1lUR1a2WjRAgCLVYeZ1ACUTVigr5qFB6t9ozpqFh5MyEKl8cReFp7cymYlghYAWIyuQgAAT+GJvSyqy20P6DoIABWArkIAAE/giROyeGIrW0UgaAFABanKM6kBAKxR0dOue+L96jyxla0iELQAAAAAN6isCSE8rZeFJ7ayVQTGaAEAAACVrLInhPCkCVmqy1hmWrQAAACASuap065XFk9rZasIBC0AAACgklWXCSGKU9XHMtN1EAAAAKhk1WVCiOqMoAUAACpcWqZD+49maNvBv7T/WEaVuSEpUF7c3L7qs6Tr4JkzZ/Tjjz8qNjZWderUseKQAACgiqismdUAb+KJ067DWjZjjCnrTuPHj9fFF1+sUaNG6cyZM+rWrZs2bdqkwMBArVy5Ut27d6+AqrpHenq6wsLClJaWptDQUHdXBwAAr5KW6dC4t7cVOug/Ic6ueUPj+UKJai3/PlpVdUKIqqYs2aBcLVr//e9/ddttt0mSPvzwQyUnJ2vPnj1atGiRHnnkEX311VflOSwAAKhiqvvMakBJqvqEEEWp6Bs1e4JyBa3U1FRFRkZKklavXq3BgwerRYsWGjVqlJ5//nlLKwgAALwXM6sBnsUTAk516U5crqAVERGhXbt2KSoqSmvWrNH8+fMlSZmZmapZs6alFQQAAN6LmdUAz+EJAaekGzVXpe7E5Zp1cMSIEbr55pt10UUXyWaz6ZprrpEkffPNN2rVqpWlFQQAAN6LmdUAz1BSwKmsmUBL0524qihXi9a0adN00UUX6dChQxo8eLD8/PwkSTVr1tTkyZMtrSAAAPBezKwGeAZPGS9ZnboTl3t695tuuqnAusTExL9VGQAAUPVE1w7QvKHxzKwGuJGnBJzq1J241EGrLJNc3HfffeWqDAAAqJqq68xqgKfwlICT3514YxG3fKhK3YlLHbSeffbZUpWz2WwELQAAAMCDeErAqU7dict1w+LqhBsWAwAAoCo4fOJ0kQEnqpKnVffWGzVX+A2LAQAAAHgXTxovWR26E5c7aP32229asWKFDh48KIfDdRrGZ5555m9XDAAAAIC1qkPA8RTlClqfffaZrr/+ejVp0kR79+7VRRddpF9//VXGGF166aVW1xEAAABANZTfxTA9K0ehAT6yB3lPUCxX0JoyZYoeeughPfHEEwoJCdGyZcsUHh6uW2+9Vb1797a6jgAAAACqmcMnThe4yXJCnF2zBrVTdCWPKSuPGuXZaffu3c57ZtWqVUunT59WcHCwnnjiCc2ePdvSCgIAAACoXtIyHQVClnT25sqTl+1QWqajiD09R7mCVlBQkLKzsyVJ0dHR2r9/v3Nbamrhd5wGAAAAcDZE7D+aoW0H/9L+YxleERoqW2qGo0DIyrdxX6pSMzz/PStX18FOnTrpq6++Ups2bdSvXz899NBD+vHHH7V8+XJ16tTJ6joCAAAAVYK7u8N5y5in9KycYrefLGG7JyhX0HrmmWeUkZEhSZo2bZoyMjK0ZMkSNW/evNQ3NgYAAACqk5K6w80bGl+hocfdIa8sQv19it0eUsJ2T1CuoNW0aVPn/wcGBmr+/PmWVQgAAACoikrTHa6igpa7Q15Z2YN9lRBnd7m5cr6EOLvswZ5T16KUa4wWAAAAgLJxZ3c4bxvzFBboq1mD2ikhzu6yPiHOrtmD2nlUKCxKuVq0atSoIZvNVuT2M2fOlLtCAAAAQFXkzu5w3jjmKbp2gOYNjVdqhkMns3IU4u8je7BnjikrTLmC1nvvvefyOCcnR9u2bdPrr7+uxx9/3JKKAQAAAFWJO7vDeeuYp7BA7wlWFypX0BowYECBdTfddJPatm2rJUuWaNSoUX+7YgAAAEBVkt8dbvKyHS5hqzK6w1WFMU/exmaMMVYdbP/+/WrXrp1OnTpl1SHdLj09XWFhYUpLS1NoaKi7qwMAAAAvlz/FemV3hzt84nSRIS/Kw2Yd9FRlyQblatEqzOnTpzVv3jw1bNjQqkMCAABUG95yfyP8fe7qDuftY568TbmCVp06dVwmwzDG6OTJkwoMDNTixYstqxwAAEB14E33N4J3q6yQxw8H5Qxazz77rEvQqlGjhurXr6+OHTuqTp06llUOAACgqvO2+xsBJeGHg7PKFbSGDx9ucTUAAACqJ3fexBawGj8cnFPqoLVjx45SH7Rdu3blqgwAAEB14433NwKKwg8H55Q6aLVv3142m035kxRyw2IAAIC/z1vvbwQUhh8OzqlR2oLJycn65ZdflJycrOXLl6tJkyaaP3++tm3bpm3btmn+/Plq1qyZli1bVpH11fz589WkSRP5+/vrsssu0xdffFFs+Q0bNuiyyy6Tv7+/mjZtqgULFlRo/QAAAMoi//5GheH+RrhQWqZD+49maNvBv7T/WIbSMh3urpILfjg4p9QtWrGxsc7/Hzx4sJ5//nn17dvXua5du3aKiYnRo48+qoEDB1payXxLlizR+PHjNX/+fHXt2lUvvfSS+vTpo127dqlRo0YFyicnJ6tv374aPXq0Fi9erK+++kpjx45V/fr1NWjQoAqpIwAAQFm48ya28C7eMMkEN0Y+p1w3LA4ICND333+v1q1bu6zfvXu3Lr30Up0+fdqyCp6vY8eOuvTSS/Xiiy8617Vu3VoDBw7UzJkzC5SfNGmSVqxYod27dzvXjRkzRtu3b9fmzZtL9ZzOm5IdPlz4Tclq1pT8/c89Lu5mzTVqSAEB5SubmSkV9VHZbFJgYPnKnj4t5eUVXY+goPKVzcqSiutCWpaygYFn6y1J2dlSbq41ZQMCzr7PkuRwSDnFNGWXpay//9nzoqxlc3LOli+Kn59Uq1bZy+bmnn0viuLrK/n4lL3smTNnP7ui+PicLV/Wsnl5Z881K8rWqnX2vZDO/k1kZlpTtix/91wjCi/LNaLsZblGnP3/KnyNSMt06PgffykjO0fBfj6qd+H9jbhGlK9sFblGpGU69NC72/XVz8edRbNr+SivRk0lxNk176aLFFZcE0olXiOOnDitRz/Y6VLXrs3r6cnBlyqq/v//fdpLrxHp6ekKi44u1Q2LZcohPj7eDBs2zJw+fdq5LisrywwbNszEx8eX55Alys7ONjVr1jTLly93WX/fffeZhISEQve58sorzX333eeybvny5aZWrVrG4XAUuk9WVpZJS0tzLocOHTKSTNrZt7fg0rev6wECAwsvJxnTrZtrWbu96LIdOriWjY0tumybNq5l27QpumxsrGvZDh2KLmu3u5bt1q3osoGBrmX79i267IWn3U03FV82I+Nc2cTE4ssePXqu7NixxZdNTj5XdsKE4svu3Hmu7NSpxZf99ttzZefMKb7sunXnyv7738WXXbnyXNmkpOLLLl16ruzSpcWXTUo6V3blyuLL/vvf58quW1d82TlzzpX99tviy06deq7szp3Fl50w4VzZ5OTiy44de67s0aPFl01MPFc2I6P4sjfdZFwUV5ZrxNmFa8S5hWvE2YVrxNmFa8TZhWvEuaUM14ghQ2eY2EkrTeyklebozH8Vf1yuEWeXv3mNSJOMJJOWlmZKUq7p3RcsWKD+/fsrJiZGl1xyiSRp+/btstlsWrlyZXkOWaLU1FSdOXNGERERLusjIiKUkpJS6D4pKSmFls/NzVVqaqqioqIK7DNz5kw9/vjj1lUcAAAAqGDZOUxG52nK1XVQkjIzM7V48WLt2bNHxhi1adNGw4YNU9D5TbkWOnz4sBo0aKBNmzapc+fOzvVPPfWU3njjDe3Zs6fAPi1atNCIESM0ZcoU57qvvvpKV1xxhY4cOaLIyMgC+2RnZyv7vObR9PR0xcTE0HWwrGVp8i97WboFnf3/KtwtqMSyXCPKV5ZrxFlcI8pelmvEWRf83R85fFyPvv9jwW5fAy5SVJ1ArhH5Kvka8cvRDPWb96VL0fyug5L02b1d1Kx20eOf0s7YlJqVp/SsHIXWkuw+Knr8H9eIs/5m18FytWhJUmBgoO66667y7l5mdrtdNWvWLNB6dfTo0QKtVvkiIyMLLV+rVi3Vq1ev0H38/Pzkl/+Gni8oyPWPuihlCZplKXv+Rc3KsudfhK0se/4/GlaW9fM7d8JbWdbX99wfnbvK+vicu/hYWbZWrXMXSyvL1qxZ+nO4LGVr1KiYsjZbxZSVPKMs14izuEaUvSzXiLO4Rkg6Ow5o4kc/64uDpyTfc397aw+ekmPN/rM3mz1/B64RZ1XCNaJehI8ub9uw6Ekm6gRJRQSnvzWJBteIs/L/7stwG6tSB60VK1aoT58+8vHx0YoVK4ote/3115e6AqXl6+uryy67TJ9++qluuOEG5/pPP/1UAwYMKHSfzp0768MPP3RZ98knn6hDhw7yKe0/QAAAANUEN5v1XOWdnTIt01EgZElnP8/Jy3acDc98phWi1EFr4MCBSklJUXh4eLHTt9tstgq7YfGDDz6o22+/XR06dFDnzp318ssv6+DBgxozZowkacqUKfr999+1aNEiSWdnGPz3v/+tBx98UKNHj9bmzZv16quv6u23366Q+gEAAHgzbjbr2aJrB2je0HilZjh0MitHIf4+sl84O+UFCM/uU+qglXden9q84vrXVqAhQ4bo+PHjeuKJJ3TkyBFddNFFWr16tfMeX0eOHNHBgwed5Zs0aaLVq1frgQce0AsvvKDo6Gg9//zz3EMLAACgENxs1vOFBRYfrC5kdXhOy3QoNcNxdqxXgI/sQWWrT3VS7jFaFzpx4oRq165t1eGKNHbsWI0dO7bQbQsXLiywrlu3bvr+++8ruFYAAADej5vNVj1WhmdvuGGyJ6lRnp1mz56tJUuWOB8PHjxYdevWVYMGDbR9+3bLKgcAAIDKkz8OKCHO7rK+pHFA8Fz54bkwZQnPJY31SsssZqbTaqpc07s3bdpUixcvVpcuXfTpp5/q5ptv1pIlS7R06VIdPHhQn3zySUXU1S3S09MVFhZWurs/AwAAVAH53cNKOw4Inu3widNFTqIRVcqWqP1HM9TzmQ1Fbv/swW5qFh78t+vq6cqSDcrVdfDIkSOKiYmRJK1cuVI333yzevXqpcaNG6tjx47lOSQAAAA8RFnHAXmT6jjGqDyTaFyIiVLKrlxBq06dOjp06JBiYmK0Zs0aTZ8+XZJkjKmwGQcBAACAv6M6jzH6u+GZiVLKrlxjtG688UYNGzZM11xzjY4fP64+ffpIkn744Qc1b97c0goCAAAAfxdjjP4eq8Z6VSflClrPPvusxo0bpzZt2ujTTz9VcPDZ/phHjhwpckZAAAAAwF1Kcz8pFI2JUsquXF0HfXx8NGHChALrx48f/3frAwAAAFiOMUZ/nxVjvaqTcrVoSdIbb7yhK664QtHR0Tpw4IAkae7cufrggw8sqxwAAEBVlJbp0P6jGdp28C/tP5ZBt7VKwBgja4QF+qpZeLDaN6qjZuHBhKxilCtovfjii3rwwQfVp08fnThxwjkBRu3atTV37lwr6wcAAFClHD5xWuPe3qaez2zQDfM3qee/Nujet7fp8InT7q5alcYYI/eqjj8ulOs+Wm3atNGMGTM0cOBAhYSEaPv27WratKl27typ7t27KzW18P6v3oj7aAEAAKukZTo07u1thY4VSoiza97QeFoIKpAV95NC2VWl2R4r/D5aycnJio+PL7Dez89Pp06dKs8hAQAAqrzSTMhA0Ko4jDGqfCXN9liVf1woV9Bq0qSJfvjhB8XGxrqs/+ijj9S6dWtLKgYAAFDVMCGD+1XlmzFXptLe+Lk6/7hQrqD18MMP65577lFWVpaMMfr222/19ttva8aMGXr11VetriMAAECVwIQMqArK0hWwOv+4UK6gNWLECOXm5mrixInKzMzUsGHD1KBBA82bN09XXnml1XUEAACoEvInZNhYxBgtJmSApytrV8Dq/ONCuad3Hz16tA4cOKCjR48qJSVF3377rbZt26bmzZtbWT8AAIAqg5u+wtuV9cbP1Xm2xzIFrRMnTujWW29V/fr1FR0dreeff15169bVCy+8oObNm+vrr7/Wa6+9VlF1BQAA8Hr5EzJ89mA3vT+2iz57sJvmDY1n1jt4hbJ2BazOPy6Uqevg//t//08bN25UYmKi1qxZowceeEBr1qxRVlaWVq9erW7dulVUPQEAAKoMJmSAtypPV8DqOttjmYLWqlWrlJSUpKuvvlpjx45V8+bN1aJFC25SDAAAAFQD5R1nWB1/XChT18HDhw+rTZs2kqSmTZvK399fd955Z4VUDAAAAIBnqc5dAcuqTC1aeXl58vE51xxYs2ZNBQUFWV4pAAAAAJ6punYFLKsyBS1jjIYPHy4/Pz9JUlZWlsaMGVMgbC1fvty6GgIAAADwKNWxK2BZlSloJSYmujy+7bbbLK0MAAAAgOopLdOh1AyH0rNyFBrgI3uQd4e5MgWtpKSkiqoHAAAAgGrq8InTBW6EnBBn16xB7RTtpbc+KPcNiwEAAADg70rLdBQIWdLZGyBPXrZDaZmOIvb0bAQtAAAAAG6TmuEoELLybdyXqtQMghYAAAAAlEl6Vk6x20+WsN1TlWmMFgAAAICqx50TUYT6+xS7PaSE7Z6KoAUAAABUY+6eiMIe7KuEOLs2FtJ9MCHOLnuwd848SNdBAAAAoJryhIkowgJ9NWtQOyXE2V3WJ8TZNXtQO6+d4p0WLQAAAKCaKs1EFJURdKJrB2je0HilZjh0MitHIf4+sgdXo/toAQAAAKg6PGkiirBA7w5WF6LrIAAAAFBNVdWJKDwBQQsAAACopvInoiiMN09E4QkIWgAAAEA1VVUnovAEjNECAAAAqrGqOBGFJyBoAQAAANVcVZuIwhPQdRAAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYl4RtH799VeNGjVKTZo0UUBAgJo1a6apU6fK4XAUu9/w4cNls9lclk6dOlVSrQEAAABUV7XcXYHS2LNnj/Ly8vTSSy+pefPm2rlzp0aPHq1Tp07p6aefLnbf3r17KykpyfnY19e3oqsLAAAAoJrziqDVu3dv9e7d2/m4adOm2rt3r1588cUSg5afn58iIyMruooAAAAA4OQVXQcLk5aWprp165ZYbv369QoPD1eLFi00evRoHT16tNjy2dnZSk9Pd1kAAAAAoCy8Mmjt379f8+bN05gxY4ot16dPH7355pv6/PPP9a9//UtbtmzRVVddpezs7CL3mTlzpsLCwpxLTEyM1dUHAADwOGmZDu0/mqFtB//S/mMZSsssfiw8gOLZjDHGXU8+bdo0Pf7448WW2bJlizp06OB8fPjwYXXr1k3dunXTf/7znzI935EjRxQbG6t33nlHN954Y6FlsrOzXYJYenq6YmJilJaWptDQ0DI9HwAAgDc4fOK0Ji3boS/2pTrXJcTZNWtQO0XXDnBjzQDPkp6errCwsFJlA7eO0Ro3bpxuueWWYss0btzY+f+HDx9Wjx491LlzZ7388stlfr6oqCjFxsZq3759RZbx8/OTn59fmY8NAADgjdIyHQVCliRt3Jeqyct2aN7QeIUFMpkYUFZuDVp2u112u71UZX///Xf16NFDl112mZKSklSjRtl7PR4/flyHDh1SVFRUmfcFAACoilIzHAVCVr6N+1KVmuEgaAHl4BVjtA4fPqzu3bsrJiZGTz/9tI4dO6aUlBSlpKS4lGvVqpXee+89SVJGRoYmTJigzZs369dff9X69evVv39/2e123XDDDe54GUC1RJ9/APBs6Vk5xW4/WcJ2eC7+DXYvr5je/ZNPPtHPP/+sn3/+WQ0bNnTZdv4Qs7179yotLU2SVLNmTf34449atGiRTpw4oaioKPXo0UNLlixRSEhIpdYfqK7o8w8Ani/U36fY7SElbIdn4t9g93PrZBjeoCwD3gCck5bp0Li3txXaHSUhzk6ffwDwEGmZDt379jZt9ILrdVqmQ6kZDqVn5Sg0wEf2IF+PqZsn4d/giuM1k2EAqLro8w8A3iEs0FezBrXT5GU7XMJWQpxdswe185hrNS00pce/wZ6BoAWgQtDnHwC8R3TtAM0bGq/UDIdOZuUoxN9H9mDPaS1iZsSy4d9gz0DQAlAh6PMPAN4lLNBzgtWFaKEpG/4N9gxeMesgAO9jD/ZVQlzht29IiLPLHsw/iACA0qGFpmz4N9gzELQAVIj8Pv8XXug9rc8/AMDz0UJTtqna+TfYM9B1EECF8fQ+/wAA75DfQlPUzIhVvYWmPBOB8G+w+zG9ewmY3h0AAMD9Dp84XeTMiFFVeNZBpmr3LEzvDgAAgCqlurbQMBGI9yJoAQAAwCt48syIFYWJQLwXk2EAAAAAHoqJQLwXQQsAAADwUEzV7r0IWgAAAICHYqp278UYLQAAAMCDVdeJQLwdQQsAAADwcNVxIhBvR9dBAAAAALAYQQsAAAAALEbXQQAAAAAVIi3TodQMh9KzchQa4CN7UPXpAknQAgAAAGC5wydOa9KyHfpiX6pzXUKcXbMGtVN07QA31qxy0HUQAAAAgKXSMh0FQpYkbdyXqsnLdigt0+GmmlUeWrQAAAAAOFnR3S81w1EgZOXbuC9VqRmOKt+FkKAFAAAAQJJ13f3Ss3KK3X6yhO1VAV0HAQAAAFja3S/U36fY7SElbK8KCFoAAAAAStXdr7Tswb5KiLMXui0hzi57cNXuNigRtAAAAADI2u5+YYG+mjWoXYGwlRBn1+xB7ar8+CyJMVoAAAAAZH13v+jaAZo3NF6pGQ6dzMpRiL+P7MHcRwsAAHi56nyjUABll9/db2Mh3QfL290vLLD6XncIWgAAVEHV/UahAMouv7vf5GU7XMJWderuZyWbMca4uxKeLD09XWFhYUpLS1NoaKi7qwMAQInSMh0a9/a2Qge1J8TZNW9oPF+YABQpvzW8tN39qlPreVmyAS1aAABUMdwoFMDfUZbufrSeF41ZBwEAqGK4USiAymDlfbeqIoIWAABVDDcKBVAZrLzvVlVE0AIAoIrhRqEAKgOt58UjaAEAUMVwo1AAlYHW8+IxGQYAAFVQdb9RKICKVxH33apKaNECAKCKCgv0VbPwYLVvVEfNwoMJWQAsRet58WjRAgAAAFAutJ4XjaAFAAAAoNzKct+t6oSugwAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWMxrglbjxo1ls9lclsmTJxe7jzFG06ZNU3R0tAICAtS9e3f99NNPlVRjAAAAoHBpmQ7tP5qhbQf/0v5jGUrLdLi7SrBYLXdXoCyeeOIJjR492vk4ODi42PJz5szRM888o4ULF6pFixaaPn26rrnmGu3du1chISEVXV0AAACggMMnTmvSsh36Yl+qc11CnF2zBrVTdO0AN9YMVvKaFi1JCgkJUWRkpHMpLmgZYzR37lw98sgjuvHGG3XRRRfp9ddfV2Zmpt56661KrDUAAABwVlqmo0DIkqSN+1I1edkOWraqEK8KWrNnz1a9evXUvn17PfXUU3I4ij4Rk5OTlZKSol69ejnX+fn5qVu3btq0aVOR+2VnZys9Pd1lAQCgOqJrE2C91AxHgZCVb+O+VKVm8HdWVXhN18H7779fl156qerUqaNvv/1WU6ZMUXJysv7zn/8UWj4lJUWSFBER4bI+IiJCBw4cKPJ5Zs6cqccff9y6igMA4IXo2gRUjPSsnGK3nyxhO7yHW1u0pk2bVmCCiwuXrVu3SpIeeOABdevWTe3atdOdd96pBQsW6NVXX9Xx48eLfQ6bzeby2BhTYN35pkyZorS0NOdy6NChv/9CAQDwInRtAipOqL9PsdtDStgO7+HWFq1x48bplltuKbZM48aNC13fqVMnSdLPP/+sevXqFdgeGRkp6WzLVlRUlHP90aNHC7Rync/Pz09+fn4lVR0AgCqrNF2bwgJ9K7lWQNVgD/ZVQpxdGwv5G0uIs8sezN9WVeHWoGW322W328u177Zt2yTJJUSdr0mTJoqMjNSnn36q+Ph4SZLD4dCGDRs0e/bs8lUYAIBqgK5NQMUJC/TVrEHtNHnZDpewlRBn1+xB7fgRowrxijFamzdv1tdff60ePXooLCxMW7Zs0QMPPKDrr79ejRo1cpZr1aqVZs6cqRtuuEE2m03jx4/XjBkzFBcXp7i4OM2YMUOBgYEaNmyYG18NAACeja5NQMWKrh2geUPjlZrh0MmsHIX4+8ge7EvIqmK8Imj5+flpyZIlevzxx5Wdna3Y2FiNHj1aEydOdCm3d+9epaWlOR9PnDhRp0+f1tixY/XXX3+pY8eO+uSTT7iHFgAAxaBrE1DxwgIJVlWdzRhj3F0JT5aenq6wsDClpaUpNDTU3dUBAKBSHD5xusiuTVHMOgigmipLNvCKFi0AAFC56NoEAH8PQQsAABSKrk0AUH5uvY8WAAAAAFRFBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALFbL3RUAAAAAPFFapkOpGQ6lZ+UoNMBH9iBfhQX6urta8BIELQAAAOACh0+c1qRlO/TFvlTnuoQ4u2YNaqfo2gFurBm8BV0HAQAAgPOkZToKhCxJ2rgvVZOX7VBapsNNNYM3IWgBAAAA50nNcBQIWfk27ktVagZBCyUjaAEAAADnSc/KKXb7yRK2AxJjtACUAoOBAQDVSai/T7HbQ0rYDkgELQAlYDAwAFRt/JhWkD3YVwlxdm0spPtgQpxd9uDq/f6gdGzGGOPuSniy9PR0hYWFKS0tTaGhoe6uDlCp0jIdGvf2tkL7qSfE2TVvaHy1/8cYALwZP6YV7fCJ05q8bIdL2EqIs2v2oHaKqubvTXVWlmxAixaAIpVmMDBBCwC8U0kz61X3H9Oiawdo3tB4pWY4dDIrRyH+PrIH09qH0iNoASgSg4EBoOrix7SShQUSrFB+zDoIoEgMBgaAqosf04CKRdACUKT8wcCFYTAwAHg3fkwDKhZBC0CRwgJ9NWtQuwJhK38wMN0pAMB78WMaULGYdbAEzDoInJv6l8HAAFC1MLMeUDbMOgjAUgwGBoCqiZn1gIpD0AIAAKjG+DENqBiM0QIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGJeEbTWr18vm81W6LJly5Yi9xs+fHiB8p06darEmgMAAACojmq5uwKl0aVLFx05csRl3aOPPqq1a9eqQ4cOxe7bu3dvJSUlOR/7+vpWSB0BAAAAIJ9XBC1fX19FRkY6H+fk5GjFihUaN26cbDZbsfv6+fm57AsAAAAAFc0rug5eaMWKFUpNTdXw4cNLLLt+/XqFh4erRYsWGj16tI4ePVps+ezsbKWnp7ssAAAAAFAWNmOMcXclyqpv376SpNWrVxdbbsmSJQoODlZsbKySk5P16KOPKjc3V9999538/PwK3WfatGl6/PHHC6xPS0tTaGjo3688AAAAAK+Unp6usLCwUmUDtwatokLN+bZs2eIyDuu3335TbGysli5dqkGDBpXp+Y4cOaLY2Fi98847uvHGGwstk52drezsbOfj9PR0xcTEELQAAACAaq4sQcutY7TGjRunW265pdgyjRs3dnmclJSkevXq6frrry/z80VFRSk2Nlb79u0rsoyfn1+RrV0AAAAAUBpuDVp2u112u73U5Y0xSkpK0h133CEfH58yP9/x48d16NAhRUVFlXlfAAAAACgtr5oM4/PPP1dycrJGjRpV6PZWrVrpvffekyRlZGRowoQJ2rx5s3799VetX79e/fv3l91u1w033FCZ1QYAAABQzXjF9O75Xn31VXXp0kWtW7cudPvevXuVlpYmSapZs6Z+/PFHLVq0SCdOnFBUVJR69OihJUuWKCQkpDKrDQAAAKCa8cpZBytTWQa8AQAAAKi6ypINvKrrIAAAAAB4A4IWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxWq5uwIonbRMh1IzHErPylFogI/sQb4KC/R1d7UAAAAAFIKg5QUOnzitSct26It9qc51CXF2zRrUTtG1A9xYMwAAAACFoeugh0vLdBQIWZK0cV+qJi/bobRMh5tqBgAAAKAoBC0Pl5rhKBCy8m3cl6rUDIIWAAAA4GkIWh4uPSun2O0nS9gOAAAAoPIRtDxcqL9PsdtDStgOAAAAoPIRtDycPdhXCXH2QrclxNllD2bmQQAAAMDTELQ8XFigr2YNalcgbCXE2TV7UDumeAcAAAA8ENO7e4Ho2gGaNzReqRkOnczKUYi/j+zB3EcLAAAA8FQELS8RFkiwAgAAALwFXQcBAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwWC13V8DTGWMkSenp6W6uCQAAAAB3ys8E+RmhOAStEpw8eVKSFBMT4+aaAAAAAPAEJ0+eVFhYWLFlbKY0caway8vL0+HDhxUSEiKbzVbhz5eenq6YmBgdOnRIoaGhFf58QEk4J+FJOB/haTgn4Uk4HyueMUYnT55UdHS0atQofhQWLVolqFGjhho2bFjpzxsaGsofCDwK5yQ8CecjPA3nJDwJ52PFKqklKx+TYQAAAACAxQhaAAAAAGAxgpaH8fPz09SpU+Xn5+fuqgCSOCfhWTgf4Wk4J+FJOB89C5NhAAAAAIDFaNECAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQcoPGjRvLZrMVWO655x5J0vDhwwts69Spk5trjaosNzdX//znP9WkSRMFBASoadOmeuKJJ5SXl+csY4zRtGnTFB0drYCAAHXv3l0//fSTG2uNqqo05yPXSVS2kydPavz48YqNjVVAQIC6dOmiLVu2OLdzjURlKul85BrpGWq5uwLV0ZYtW3TmzBnn4507d+qaa67R4MGDnet69+6tpKQk52NfX99KrSOql9mzZ2vBggV6/fXX1bZtW23dulUjRoxQWFiY7r//fknSnDlz9Mwzz2jhwoVq0aKFpk+frmuuuUZ79+5VSEiIm18BqpLSnI8S10lUrjvvvFM7d+7UG2+8oejoaC1evFhXX321du3apQYNGnCNRKUq6XyUuEZ6AqZ39wDjx4/XypUrtW/fPtlsNg0fPlwnTpzQ+++/7+6qoZq47rrrFBERoVdffdW5btCgQQoMDNQbb7whY4yio6M1fvx4TZo0SZKUnZ2tiIgIzZ49W3fffbe7qo4qqKTzURLXSVSq06dPKyQkRB988IH69evnXN++fXtdd911evLJJ7lGotKUdD5Onz6da6SHoOugmzkcDi1evFgjR46UzWZzrl+/fr3Cw8PVokULjR49WkePHnVjLVHVXXHFFfrss8/0v//9T5K0fft2ffnll+rbt68kKTk5WSkpKerVq5dzHz8/P3Xr1k2bNm1yS51RdZV0PubjOonKkpubqzNnzsjf399lfUBAgL788kuukahUJZ2P+bhGuh9dB93s/fff14kTJzR8+HDnuj59+mjw4MGKjY1VcnKyHn30UV111VX67rvvuNM3KsSkSZOUlpamVq1aqWbNmjpz5oyeeuopDR06VJKUkpIiSYqIiHDZLyIiQgcOHKj0+qJqK+l8lLhOonKFhISoc+fOevLJJ9W6dWtFRETo7bff1jfffKO4uDiukahUJZ2PEtdIT0HQcrNXX31Vffr0UXR0tHPdkCFDnP9/0UUXqUOHDoqNjdWqVat04403uqOaqOKWLFmixYsX66233lLbtm31ww8/aPz48YqOjlZiYqKz3PmtrtLZwd8XrgP+rtKcj1wnUdneeOMNjRw5Ug0aNFDNmjV16aWXatiwYfr++++dZbhGorKUdD5yjfQMBC03OnDggNauXavly5cXWy4qKkqxsbHat29fJdUM1c3DDz+syZMn65ZbbpEkXXzxxTpw4IBmzpypxMRERUZGSjrbshUVFeXc7+jRowV+wQX+rpLOx8JwnURFa9asmTZs2KBTp04pPT1dUVFRGjJkiJo0acI1EpWuuPOxMFwj3YMxWm6UlJSk8PBwl4GMhTl+/LgOHTrkcvEGrJSZmakaNVwvBzVr1nROp53/ReLTTz91bnc4HNqwYYO6dOlSqXVF1VfS+VgYrpOoLEFBQYqKitJff/2ljz/+WAMGDOAaCbcp7HwsDNdI96BFy03y8vKUlJSkxMRE1ap17mPIyMjQtGnTNGjQIEVFRenXX3/V//t//092u1033HCDG2uMqqx///566qmn1KhRI7Vt21bbtm3TM888o5EjR0o62x1m/PjxmjFjhuLi4hQXF6cZM2YoMDBQw4YNc3PtUdWUdD5ynYQ7fPzxxzLGqGXLlvr555/18MMPq2XLlhoxYgTXSFS64s5HrpEexMAtPv74YyPJ7N2712V9Zmam6dWrl6lfv77x8fExjRo1MomJiebgwYNuqimqg/T0dHP//febRo0aGX9/f9O0aVPzyCOPmOzsbGeZvLw8M3XqVBMZGWn8/PxMQkKC+fHHH91Ya1RVJZ2PXCfhDkuWLDFNmzY1vr6+JjIy0txzzz3mxIkTzu1cI1GZijsfuUZ6Du6jBQAAAAAWY4wWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAVDPTpk1T+/btnY+HDx+ugQMHVno9fv31V9lsNv3www+V/twl6d69u8aPH18pz2Wz2fT+++9XynN5ms8//1ytWrVSXl5euY+xcuVKxcfH/61jAEBFIGgBgAcYPny4bDabbDabfHx81LRpU02YMEGnTp2q8Od+7rnntHDhwlKVdUc4+vnnnzVy5Eg1atRIfn5+atCggXr27Kk333xTubm5lVaPv+vCgJvvyJEj6tOnT4U+98KFC53nl81mU0REhPr376+ffvqpzMepXbu2ZfWaOHGiHnnkEdWocfbryLZt2xQfH6/g4GBdf/31+uuvv5xlc3Nzdemll2rLli0ux7juuutks9n01ltvWVYvALACQQsAPETv3r115MgR/fLLL5o+fbrmz5+vCRMmFFo2JyfHsucNCwuz9Muzlb799ltdeuml2r17t1544QXt3LlTK1eu1MiRI7VgwYJig4KV71FFioyMlJ+fX4U/T2hoqI4cOaLDhw9r1apVOnXqlPr16yeHw1Hhz12YTZs2ad++fRo8eLBz3Z133qmrrrpK33//vU6cOKEZM2Y4tz399NO64oordPnllxc41ogRIzRv3rxKqTcAlBZBCwA8hJ+fnyIjIxUTE6Nhw4bp1ltvdXYpy28Nee2119S0aVP5+fnJGKO0tDTdddddCg8PV2hoqK666ipt377d5bizZs1SRESEQkJCNGrUKGVlZblsv7DrYF5enmbPnq3mzZvLz89PjRo10lNPPSVJatKkiSQpPj5eNptN3bt3d+6XlJSk1q1by9/fX61atdL8+fNdnufbb79VfHy8/P391aFDB23btq3Y98MYo+HDh6tFixb66quv1L9/f8XFxSk+Pl633nqrvvjiC7Vr107SuZa2pUuXqnv37vL399fixYt1/PhxDR06VA0bNlRgYKAuvvhivf322y7Pc+rUKd1xxx0KDg5WVFSU/vWvfxWoS2Hd+2rXru3SEjhp0iS1aNFCgYGBatq0qR599FFn2Fu4cKEef/xxbd++3dmqlL/vhcf+8ccfddVVVykgIED16tXTXXfdpYyMDOf2/M/r6aefVlRUlOrVq6d77rmnxGBps9kUGRmpqKgodejQQQ888IAOHDigvXv3Oss888wzuvjiixUUFKSYmBiNHTvW+dzr16/XiBEjlJaW5nwN06ZNkyQ5HA5NnDhRDRo0UFBQkDp27Kj169cXW5933nlHvXr1kr+/v3Pd7t27NXr0aLVo0UJDhw7Vrl27JEm//PKLXnvtNed5eKHrr79e3377rX755ZdinxMAKhNBCwA8VEBAgMuX559//llLly7VsmXLnF33+vXrp5SUFK1evVrfffedLr30UvXs2VN//vmnJGnp0qWaOnWqnnrqKW3dulVRUVEFAtCFpkyZotmzZ+vRRx/Vrl279NZbbykiIkLS2bAkSWvXrtWRI0e0fPlySdIrr7yiRx55RE899ZR2796tGTNm6NFHH9Xrr78u6WyYue6669SyZUt99913mjZtWpGtdfl++OEH7d69WxMmTHB2LbuQzWZzeTxp0iTdd9992r17t6699lplZWXpsssu08qVK7Vz507ddddduv322/XNN98493n44Ye1bt06vffee/rkk0+0fv16fffdd8XWrTAhISFauHChdu3apeeee06vvPKKnn32WUnSkCFD9NBDD6lt27Y6cuSIjhw5oiFDhhQ4RmZmpnr37q06depoy5Ytevfdd7V27VqNGzfOpdy6deu0f/9+rVu3Tq+//roWLlxY6u6fknTixAlnVzsfHx/n+ho1auj555/Xzp079frrr+vzzz/XxIkTJUldunTR3LlznS1jR44ccX6GI0aM0FdffaV33nlHO3bs0ODBg9W7d2/t27evyDps3LhRHTp0cFl3ySWX6NNPP1Vubq4+++wzZ5AeM2aM5syZo5CQkEKPFRsbq/DwcH3xxRelfg8AoMIZAIDbJSYmmgEDBjgff/PNN6ZevXrm5ptvNsYYM3XqVOPj42OOHj3qLPPZZ5+Z0NBQk5WV5XKsZs2amZdeeskYY0znzp3NmDFjXLZ37NjRXHLJJYU+d3p6uvHz8zOvvPJKofVMTk42ksy2bdtc1sfExJi33nrLZd2TTz5pOnfubIwx5qWXXjJ169Y1p06dcm5/8cUXCz1WvnfeecdIMt9//71z3R9//GGCgoKcywsvvOBSr7lz5xZ6rPP17dvXPPTQQ8YYY06ePGl8fX3NO++849x+/PhxExAQYO6//37nOknmvffeczlOWFiYSUpKKvJ55syZYy677DLn46lTp7q874Ud++WXXzZ16tQxGRkZzu2rVq0yNWrUMCkpKcaYs59XbGysyc3NdZYZPHiwGTJkSJF1SUpKMpJMUFCQCQwMNJKMJHP99dcXuY8xxixdutTUq1fP5ThhYWEuZX7++Wdjs9nM77//7rK+Z8+eZsqUKUUeOywszCxatMhl3c6dO01CQoJp1KiRGTp0qElLSzOvv/66GTBggPntt99Mr169TLNmzcwjjzxS4Hjx8fFm2rRpxb4eAKhMtdyW8AAALlauXKng4GDl5uYqJydHAwYMcBl3Ehsbq/r16zsff/fdd8rIyFC9evVcjnP69Gnt379f0tmuWGPGjHHZ3rlzZ61bt67QOuzevVvZ2dnq2bNnqet97NgxHTp0SKNGjdLo0aOd63NzcxUWFuY87iWXXKLAwECXepTG+a1W9erVc7bmde/evcD4ogtbSM6cOaNZs2ZpyZIl+v3335Wdna3s7GwFBQVJkvbv3y+Hw+FSl7p166ply5alqtv5/vvf/2ru3Ln6+eeflZGRodzcXIWGhpbpGPnvU379JKlr167Ky8vT3r17nS2Lbdu2Vc2aNZ1loqKi9OOPPxZ77JCQEH3//ffKzc3Vhg0b9H//939asGCBS5l169ZpxowZ2rVrl9LT05Wbm6usrCydOnXKpU7n+/7772WMUYsWLVzWZ2dnFzg3z3f69GmXboP5r2vDhg3Ox8ePH9e0adO0ceNG3XvvveratauWL1+uyy+/XB07dlT//v2dZQMCApSZmVnsewAAlYmgBQAeokePHnrxxRfl4+Oj6Oholy5dkgp80c3Ly1NUVFShY2HKO7lFQEBAmffJn1b7lVdeUceOHV225YcBY0yZjxsXFydJ2rNnj3O2vpo1a6p58+aSpFq1Cv4TduF79K9//UvPPvus5s6d6xx7NH78eGdAK229bDZbgbLnd+v8+uuvdcstt+jxxx/Xtddeq7CwML3zzjuFjvcqjjGmQHfI8+uQ78Jzw2azlTi9eY0aNZzvXatWrZSSkqIhQ4Zo48aNkqQDBw6ob9++GjNmjJ588knVrVtXX375pUaNGlXs+K+8vDzVrFlT3333nUv4k6Tg4OAi97Pb7S6zChbmgQce0Pjx49WwYUOtX79e06dPV1BQkPr166f169e7BK0///zT5YcIAHA3xmgBgIcICgpS8+bNFRsbW+CLdGEuvfRSpaSkqFatWmrevLnLYrfbJUmtW7fW119/7bLfhY/PFxcXp4CAAH322WeFbvf19ZV0tqUoX0REhBo0aKBffvmlQD3yJ89o06aNtm/frtOnT5eqHtLZCTdatWqlp59+utz3SPriiy80YMAA3XbbbbrkkkvUtGlTl3FDzZs3l4+Pj0td/vrrL/3vf/9zOU79+vV15MgR5+N9+/a5tJ589dVXio2N1SOPPKIOHTooLi5OBw4ccDmGr6+vy/tWmDZt2uiHH35wmdb/q6++Uo0aNQq0GP1dDzzwgLZv36733ntPkrR161bl5ubqX//6lzp16qQWLVro8OHDJb6G+Ph4nTlzRkePHi3w+UdGRhb5/PHx8c7JLgrz2Wefac+ePc7xaWfOnHEGvpycHJd6ZGVlaf/+/YqPjy/bmwAAFYigBQBe6uqrr1bnzp01cOBAffzxx/r111+1adMm/fOf/9TWrVslSffff79ee+01vfbaa/rf//6nqVOnFjslur+/vyZNmqSJEydq0aJF2r9/v77++mu9+uqrkqTw8HAFBARozZo1+uOPP5SWlibp7KyIM2fO1HPPPaf//e9/+vHHH5WUlKRnnnlGkjRs2DDVqFFDo0aN0q5du7R69Wo9/fTTxb4+m82mpKQk7d27V127dtWKFSu0b98+7dq1SwsWLNCxY8cKtKBcqHnz5vr000+1adMm7d69W3fffbdSUlKc24ODgzVq1Cg9/PDD+uyzz7Rz504NHz68wOQbV111lf7973/r+++/19atWzVmzBiXMNy8eXMdPHhQ77zzjvbv36/nn3/eGWDyNW7cWMnJyfrhhx+Umpqq7OzsAvW99dZb5e/vr8TERO3cuVPr1q3Tvffeq9tvv93ZbdAqoaGhuvPOOzV16lQZY9SsWTPl5uZq3rx5+uWXX/TGG28U6FrYuHFjZWRk6LPPPlNqaqoyMzPVokUL3Xrrrbrjjju0fPlyJScna8uWLZo9e7ZWr15d5PNfe+21+vLLLwvddvr0ad1zzz16+eWXnZ9F165d9cILL2j79u1atmyZunbt6iz/9ddfy8/Pr9TdUQGgUrhzgBgA4KwLJ8O4UFETKaSnp5t7773XREdHGx8fHxMTE2NuvfVWc/DgQWeZp556ytjtdhMcHGwSExPNxIkTi5wMwxhjzpw5Y6ZPn25iY2ONj4+PadSokZkxY4Zz+yuvvGJiYmJMjRo1TLdu3Zzr33zzTdO+fXvj6+tr6tSpYxISEszy5cud2zdv3mwuueQS4+vra9q3b2+WLVtW7GQY+fbu3WsSExNNw4YNTa1atUxYWJhJSEgwL730ksnJyTHGFD1Jx/Hjx82AAQNMcHCwCQ8PN//85z/NHXfc4fJ6T548aW677TYTGBhoIiIizJw5c0y3bt1cJsP4/fffTa9evUxQUJCJi4szq1evLjAZxsMPP2zq1atngoODzZAhQ8yzzz7rMnFEVlaWGTRokKldu7aR5NxXF0y0sWPHDtOjRw/j7+9v6tata0aPHm1OnjxZ5OdljDH333+/y2dxocImsTDGmAMHDphatWqZJUuWGGOMeeaZZ0xUVJQJCAgw1157rVm0aJGRZP766y/nPmPGjDH16tUzkszUqVONMcY4HA7z2GOPmcaNGxsfHx8TGRlpbrjhBrNjx44i6/Tnn3+agIAAs2fPngLbJk+e7JywJN++ffvM5ZdfbkJDQ82YMWPMmTNnnNvuuusuc/fddxf5XADgDjZjytFxHgAA4G+aOHGi0tLS9NJLL5X7GMeOHVOrVq20detWZ1dVAPAEdB0EAABu8cgjjyg2NrbEsWvFSU5O1vz58wlZADwOLVoAAAAAYDFatAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBi/x+LZWGDjJzqVwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#residuals plot for the rf_model_2\n",
+    "residuals_rf = y_test - y_pred_test_rf\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "sns.scatterplot(x=y_pred_test_rf, y=residuals_rf)\n",
+    "plt.axhline(0, color='red', linestyle='--')\n",
+    "plt.title(\"Residuals vs Predicted Values (RF Model)\")\n",
+    "plt.xlabel(\"Predicted Graduation Rate (%)\")\n",
+    "plt.ylabel(\"Residuals\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b14a3d82",
+   "metadata": {},
+   "source": [
+    "## XGBOOST MODEL \n",
+    "\n",
+    "#### E.T."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 408,
+   "id": "201d45af",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGBoost Cross-validation MSE scores: [27.20108513 23.09804587 19.39571041 12.95533592 19.49675295]\n",
+      "Mean MSE (XGBoost): 20.429386055591873\n",
+      "Standard Deviation of MSE (XGBoost): 4.706960140935808\n"
+     ]
+    }
+   ],
+   "source": [
+    "# XGBoost cross-validation\n",
+    "from xgboost import XGBRegressor\n",
+    "from sklearn.model_selection import cross_val_score \n",
+    "\n",
+    "xgb_model_cv = XGBRegressor(objective='reg:squarederror', random_state=42)\n",
+    "xgb_cv_scores = cross_val_score(xgb_model_cv, X_train_scaled, y_train, cv=5, scoring='neg_mean_squared_error')\n",
+    "\n",
+    "# Convert negative MSE scores to positive\n",
+    "xgb_cv_scores = -xgb_cv_scores\n",
+    "\n",
+    "print(\"XGBoost Cross-validation MSE scores:\", xgb_cv_scores)\n",
+    "print(\"Mean MSE (XGBoost):\", np.mean(xgb_cv_scores))\n",
+    "print(\"Standard Deviation of MSE (XGBoost):\", np.std(xgb_cv_scores))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 409,
+   "id": "d660f856",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train MSE (XGBoost): 9.027582101139514e-07\n",
+      "Train R2 (XGBoost): 0.9999999815648231\n"
+     ]
+    }
+   ],
+   "source": [
+    "# XGBoost model metrics for training set\n",
+    "xgb_model_cv.fit(X_train_scaled, y_train)\n",
+    "y_train_pred_xgb = xgb_model_cv.predict(X_train_scaled) \n",
+    "\n",
+    "# Training set metrics for XGBoost\n",
+    "print(\"Train MSE (XGBoost):\", mean_squared_error(y_train, y_train_pred_xgb))\n",
+    "print(\"Train R2 (XGBoost):\", r2_score(y_train, y_train_pred_xgb))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 410,
+   "id": "3a826d01",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test MSE (XGBoost): 12.265545629249775\n",
+      "Test R2 (XGBoost): 0.715093270754831\n"
+     ]
+    }
+   ],
+   "source": [
+    "# check metrics for test set\n",
+    "y_pred_test_xgb = xgb_model_cv.predict(X_test_scaled)\n",
+    "\n",
+    "# Calculate metrics on test set\n",
+    "test_mse_xgb = mean_squared_error(y_test, y_pred_test_xgb)\n",
+    "test_r2_xgb = r2_score(y_test, y_pred_test_xgb)\n",
+    "\n",
+    "print(\"Test MSE (XGBoost):\", test_mse_xgb)\n",
+    "print(\"Test R2 (XGBoost):\", test_r2_xgb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 411,
+   "id": "f2b8d5ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1oAAAIhCAYAAABXMMsoAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAa91JREFUeJzt3Xd0VNXi9vFnQnoFEkISSmihCCJBrjQNTRFQRAVFUAlFlJ8VEClXEVCUclFRLHgVQ7OgF1RErgrSVEBBmlyKEUNRiBg0CSGkkf3+kTcjQ3o8KZN8P2vNWsw5+8zsmTk5zDO72YwxRgAAAAAAy7hUdAUAAAAAoKohaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoASjS4sWLZbPZ7DdXV1eFhobqjjvuUGxsbJk97/Tp02Wz2YpVtlGjRho+fHiZ1aWk9alojRo1cvjMfH191bFjRy1durRcnj/3nDl69Kh9W/fu3dW9e/cSP9azzz6rjz76yLK65Tp69KhsNpsWL15cYJlx48bJZrPp0KFDBZZ5/PHHZbPZtGvXrmI/d3mcr3/XU089pcsuu0zZ2dmSpM2bN8vFxUX//Oc/85Q9cuSIfH19NWjQoDz71qxZowEDBigsLEzu7u7y8/NTZGSkpk2bpuPHjzuU7d69u8N56+bmpkaNGmnUqFE6duxY2bzQEti6daumT5+uxMTEYpXPvWa4uLjo559/zrP/3Llz8vf3l81ms/R8KM65XZBNmzbJZrNp06ZN9m1Tp05V+/bt7ecCgOIhaAEotpiYGG3btk3r16/Xgw8+qNWrV+vqq6/Wn3/+WSbPd88992jbtm1l8tjVQdeuXbVt2zZt27bNHnyio6P12muvVUh9Xn31Vb366qslPq6sglZxjBo1SpL01ltv5bs/OztbS5cuVbt27dS+ffvyrFqZOnnypObOnaunnnpKLi45XxW6deumhx9+WHPnztV3331nL5udna3o6Gh5e3s7nFu52/v376/MzEzNmjVL69at0wcffKBbb71Vy5YtU9euXfM8d5MmTezn7ZdffqmJEydqzZo1uuaaa5Samlr2L74QW7du1YwZM4odtHL5+voqJiYmz/YPPvhAmZmZcnNzs6iGZWPChAmKi4vTkiVLKroqgFMhaAEotjZt2qhTp07q3r27Hn/8cU2ePFmnT58usy/B9evXV6dOncrksauDmjVrqlOnTurUqZMGDRqkzz77TP7+/nr++ecLPObChQtKT08vk/pcdtlluuyyy8rksctKmzZtdNVVV2nZsmXKysrKs/+LL77QL7/8Yg9kVcWLL76omjVr6tZbb3XYPmvWLDVt2lTR0dFKS0uTJM2bN0/ffPONFi5cqDp16tjLzpkzR0uXLtWsWbO0du1aRUdHq1u3burTp4+mTp2qH3/8UZMnT87z3F5eXvbzNioqSvfff79mzZqlEydO6Ouvvy7bF15GBg8erCVLluRpEVq0aJFuueUWubu7V1DNiicgIEB33XWXZs+eLWNMRVcHcBoELQCl1qFDB0nSb7/95rB9586duummm1S7dm15enoqMjJS77//vkOZ1NRUTZgwQY0bN5anp6dq166tDh066N1337WXya+rXmZmpiZOnKiQkBB5e3vr6quvdvh1vbBjpfy7tK1YsUK9e/dWaGiovLy81KpVK02ePFnnzp0r8j3YsGGDunfvrsDAQHl5ealhw4YaOHBgob+833zzzQoPD8+3G07Hjh0dWkY++OADdezYUQEBAfL29laTJk00cuTIIuuVn5o1a6pFixb2Lli53Yvmzp2rmTNnqnHjxvLw8NDGjRslFe9zlKTt27era9eu8vT0VFhYmKZMmaLMzMw85fLrOpienq6nnnpKrVq1kqenpwIDA9WjRw9t3bpVkmSz2XTu3DktWbLE3p3s4seIj4/Xfffdp/r168vd3V2NGzfWjBkz8oSikydP6vbbb5efn58CAgI0ePBgxcfHF+t9GzVqlOLj4/Xf//43z76YmBh5eHjozjvvVFpamh599FG1a9dOAQEBql27tjp37qyPP/64yOfI77yU8u/GJUnr169Xr1695O/vL29vb3Xt2lVffvmlQ5nff/9d9957rxo0aCAPDw/VqVNHXbt21fr16wutS0ZGhhYtWqShQ4faW7NyeXl5afHixfrxxx/1z3/+U/v379eTTz6pO++80yGUZWRkaO7cuWrTpk2+YUqSXF1d9cADDxTxzuQICAiQpDwtP19//bV69eolPz8/eXt7q0uXLvr000/zHL9//34NGDBAtWrVkqenp9q1a5endSY7O1szZ85UixYt5OXlpZo1a6pt27Z68cUXJeVcUx577DFJUuPGje3n46WfTX5GjhypEydOaN26dfZtP/74o77++usC/56PHz+uu+66S8HBwfLw8FCrVq303HPP5blulOTcLu7fdH7uvvtu/fjjj/brA4CiuVZ0BQA4r7i4OElS8+bN7ds2btyoPn36qGPHjlq4cKECAgL03nvvafDgwUpNTbWPQxg/fryWLVummTNnKjIyUufOndP+/ft15syZQp9z9OjRWrp0qSZMmKDrrrtO+/fv16233qqzZ8+W+nXExsaqX79+Gjt2rHx8fHTo0CHNmTNH3333nTZs2FDgcUePHtUNN9yga665Rm+99ZZq1qypX3/9VZ999pkyMjLk7e2d73EjR47UgAEDtGHDBl177bX27YcOHdJ3332nl156SZK0bds2DR48WIMHD9b06dPl6empY8eOFVqnwmRmZurYsWMOrQ6S9NJLL6l58+aaN2+e/P39FRERUezP8cCBA+rVq5caNWqkxYsXy9vbW6+++qreeeedIuuTlZWlvn376quvvtLYsWPVs2dPZWVlafv27Tp+/Li6dOmibdu2qWfPnurRo4emTp0qSfL395eUE7Kuuuoqubi46Mknn1TTpk21bds2zZw5U0ePHrV31Tp//ryuvfZanTx5UrNmzVLz5s316aefavDgwcV634YMGaJx48bprbfeUv/+/e3b//zzT3388ce65ZZbVKtWLSUlJemPP/7QhAkTVK9ePWVkZGj9+vW69dZbFRMTo2HDhhXr+YqyfPlyDRs2TAMGDNCSJUvk5uam119/Xddff70+//xz9erVS1LOF+Ndu3bpmWeeUfPmzZWYmKhdu3YV+Tf27bff6syZM+rRo0e++zt37qwJEyZo3rx5+uijjxQYGKgFCxY4lNm5c6cSExP1f//3f6V6jblBOSMjQ/v379dTTz2lJk2aqEuXLvYymzdv1nXXXae2bdtq0aJF8vDw0Kuvvqr+/fvr3XfftX++hw8fVpcuXRQcHKyXXnpJgYGBWr58uYYPH67ffvtNEydOlCTNnTtX06dP1xNPPKGoqChlZmbq0KFD9m6C99xzj/744w8tWLBAq1atUmhoqCQVq5U2IiLCfp24/vrrJeV0R23UqJH987rY77//ri5duigjI0NPP/20GjVqpDVr1mjChAk6cuSIvQtuSc7t4v5NF+TKK6+Ur6+vPv30U/Xs2bPI1wxAkgGAIsTExBhJZvv27SYzM9OcPXvWfPbZZyYkJMRERUWZzMxMe9mWLVuayMhIh23GGHPjjTea0NBQc+HCBWOMMW3atDE333xzoc87bdo0c/Fl6uDBg0aSGTdunEO5t99+20gy0dHRBR576WuJi4vL9zmzs7NNZmam2bx5s5Fk9u7dW+Bj/uc//zGSzJ49ewp9HZfKzMw0devWNUOHDnXYPnHiROPu7m4SEhKMMcbMmzfPSDKJiYklenxjjAkPDzf9+vUzmZmZJjMz08TFxZno6GgjyTz22GPGGGPi4uKMJNO0aVOTkZHhcHxxP8fBgwcbLy8vEx8fby+TlZVlWrZsmed97tatm+nWrZv9/tKlS40k88YbbxT6Wnx8fBw+21z33Xef8fX1NceOHXPYnvu+/e9//zPGGPPaa68ZSebjjz92KDd69GgjycTExBT6/MYYEx0dbdzc3Mxvv/1m37ZgwQIjyaxbty7fY7KyskxmZqYZNWqUiYyMdNgXHh7u8JoKOi83btxoJJmNGzcaY4w5d+6cqV27tunfv79DuQsXLpgrrrjCXHXVVfZtvr6+ZuzYsUW+tkvNmTPHSHL4TC91/vx5ExAQYCSZ//znP3n2v/fee0aSWbhwYZ59uedk7u1i3bp1M5Ly3Jo3b24OHjzoULZTp04mODjYnD171r4tKyvLtGnTxtSvX99kZ2cbY4y54447jIeHhzl+/LjD8X379jXe3t72v68bb7zRtGvXrtD35l//+leh149L5V4zfv/9dxMTE2M8PDzMmTNnTFZWlgkNDTXTp083xuQ9xydPnmwkmW+//dbh8f7v//7P2Gw2c/jwYWNMyc7t4v5NX3rOXaxr166mY8eOxXrtAIyh6yCAYuvUqZPc3Nzk5+enPn36qFatWvr444/l6prTOP7TTz/p0KFDuvPOOyXl/Cqde+vXr59OnTqlw4cPS5Kuuuoq/fe//9XkyZO1adMmnT9/vsjnz+2ykvv4uW6//XZ7HUrj559/1tChQxUSEqIaNWrIzc1N3bp1kyQdPHiwwOPatWsnd3d33XvvvVqyZEm+s4rlx9XVVXfddZdWrVqlpKQkSTljo5YtW6YBAwYoMDBQkvSPf/zD/vref/99/frrryV6XWvXrpWbm5vc3NzUuHFjvf/++3rooYc0c+ZMh3I33XSTQ5esknyOGzduVK9evVS3bl378TVq1ChWa9F///tfeXp6lror5Jo1a9SjRw+FhYU51LFv376Sclo8cuvo5+enm266yeH4oUOHFvu5Ro0apczMTC1btsy+LSYmRuHh4Q4tEh988IG6du0qX19fubq6ys3NTYsWLSr0PCqJrVu36o8//lB0dLTDa87OzlafPn20Y8cOe5fXq666SosXL9bMmTO1ffv2fLtz5ufkyZOy2WwKCgoqsExMTIySkpLk4uLi0B2uKImJifZzMve2c+dOhzJNmzbVjh07tGPHDm3btk3vvPOOvLy81KtXL/ssp+fOndO3336rQYMGydfX135sjRo1dPfdd+uXX36xn6MbNmxQr1691KBBA4fnGT58uFJTU+0T7lx11VXau3ev7r//fn3++edKTk4u9usqjttuu03u7u56++23tXbtWsXHxxfYirRhwwZddtlluuqqq/LU2Rhjb9Uu7rldkr/pwgQHB5f4OgRUZwQtAMW2dOlS7dixQxs2bNB9992ngwcPasiQIfb9uWO1JkyYkOfL1P333y9JSkhIkJTTXW3SpEn66KOP1KNHD9WuXVs333xzodPF53Z5CgkJcdju6upqDycllZKSomuuuUbffvutZs6cqU2bNmnHjh1atWqVJBUaAJs2bar169crODhYDzzwgJo2baqmTZvax3QUZuTIkUpLS9N7770nSfr888916tQpjRgxwl4mKipKH330kbKysjRs2DDVr19fbdq0cRjHVpirr75aO3bs0M6dO3XgwAElJibqpZdeyjPwPrcLVK6SfI5nzpzJ83lIeT+j/Pz+++8KCwvLMw6ouH777Td98skneerYunXrPHW8OAiWpI65rrnmGjVv3tzeHXHfvn3atWuXRowYYR8LuGrVKt1+++2qV6+eli9frm3btmnHjh32z9oKuZ/NoEGD8rzuOXPmyBijP/74Q1LO2MPo6Gi9+eab6ty5s2rXrq1hw4YVOTbt/PnzcnNzU40aNfLd//PPP+uxxx7TLbfcoqlTp+r111/PM+6rYcOGkpRnSnY/Pz97iJo2bVq+j+/p6akOHTqoQ4cO6tSpk4YMGaL//ve/OnXqlJ588klJOd02jTF5zl1JCgsLk/TX9eLMmTPFKjdlyhTNmzdP27dvV9++fRUYGKhevXrlCYKl5ePjo8GDB+utt97SokWLdO211yo8PDzfssWtc3HP7ZL8TRfG09OzWD+KAcjBGC0AxdaqVSv7BBg9evTQhQsX9Oabb+o///mPBg0aZP8FfMqUKXlmK8vVokULSTlfOmbMmKEZM2bot99+s7du9e/fv8A1i3LDVHx8vOrVq2ffnpWVlWfciaenp6ScyRY8PDzs2y/9MrFhwwadPHlSmzZtsrdiSSr29M3XXHONrrnmGl24cEE7d+7UggULNHbsWNWtW1d33HFHgcfl/lodExOj++67TzExMQoLC1Pv3r0dyg0YMEADBgxQenq6tm/frlmzZmno0KFq1KiROnfuXGjdAgIC7J9XYS6dNKQkn2NgYGC+X9yLM9FEnTp19PXXXys7O7tUYSsoKEht27bVM888k+/+3C+lgYGB+U6YUtzJMHKNHDlSkydP1nfffad33nlHLi4uDi0Sy5cvV+PGjbVixQqH97Q4szhefL5e7NLzNfezWbBgQYEzcuZ+8Q4KCtL8+fM1f/58HT9+XKtXr7bPFPrZZ58VWJegoCBlZGTo3Llz8vHxcdhnjNGIESPk5eWlhQsXqlatWvroo490zz336IcffpCfn5+knPE8tWrV0ieffKJnn33WfnyNGjXs5+T+/fuLfF9yhYaGKigoSHv37pUk1apVSy4uLjp16lSesidPnrS/Dinn8y9OOVdXV40fP17jx49XYmKi1q9fr3/+85+6/vrrdeLEiQLHXJbEyJEj9eabb2rfvn16++23CyxX3DoX99wuyd90Yf74449CWzoBOKJFC0CpzZ07V7Vq1dKTTz6p7OxstWjRQhEREdq7d6/9F+lLb7lfxC5Wt25dDR8+XEOGDNHhw4cLnLEvd7a5S7+gvP/++3lmmWvUqJGknJaHi33yyScO93O/EF8cxiTp9ddfL/zFX6JGjRrq2LGjXnnlFUkq1uK1I0aM0Lfffquvv/5an3zyiaKjowtsRfDw8FC3bt00Z84cSdLu3btLVL+SKMnn2KNHD3355ZcOM09euHBBK1asKPJ5+vbtq7S0tCIXVfXw8Mj3V/Qbb7xR+/fvV9OmTfOtY27Q6tGjh86ePavVq1c7HF+cCTsuFh0dLVdXV73++ut6++231atXL4cWCZvNJnd3d4eQFR8fX6xZBws6Xy+tc9euXVWzZk0dOHCgwM8mv6nCGzZsqAcffFDXXXddkedmy5YtJeUsQnypF198UVu2bNFrr72m4OBgubm5afHixTp58qR9Rj5Jcnd312OPPab9+/fbz9m/45dfflFCQoKCg4Ml5fxQ07FjR61atcrh3MjOztby5ctVv359+yQ9vXr1sv+gcrGlS5fK29s738Bas2ZNDRo0SA888ID++OMP+2yQudeJ0rbqdO7cWSNHjtQtt9yiW265pcByvXr10oEDB/J8VkuXLpXNZrNPVFLcc7u01+ZL/fzzz063RANQkWjRAlBqtWrV0pQpUzRx4kS98847uuuuu/T666+rb9++uv766zV8+HDVq1dPf/zxhw4ePKhdu3bpgw8+kJQzjfmNN96otm3bqlatWjp48KCWLVumzp07F/jLcatWrXTXXXdp/vz5cnNz07XXXqv9+/fbZ8u7WL9+/VS7dm2NGjVKTz31lFxdXbV48WKdOHHCoVyXLl1Uq1YtjRkzRtOmTZObm5vefvtt+y/nhVm4cKE2bNigG264QQ0bNlRaWpp9YduLZxMsyJAhQzR+/HgNGTJE6enpecZrPPnkk/rll1/Uq1cv1a9fX4mJiXrxxRcdxpCVleJ+jk888YRWr16tnj176sknn5S3t7deeeWVYk2NP2TIEMXExGjMmDE6fPiwevTooezsbH377bdq1aqVvUXw8ssv16ZNm/TJJ58oNDRUfn5+atGihZ566imtW7dOXbp00cMPP6wWLVooLS1NR48e1dq1a7Vw4ULVr19fw4YN0wsvvKBhw4bpmWeeUUREhNauXavPP/+8RO9JSEiI+vXrp5iYGBlj8qyddeONN2rVqlW6//77NWjQIJ04cUJPP/20QkNDC+0SK+WMx2vRooUmTJigrKws1apVSx9++GGedaN8fX21YMECRUdH648//tCgQYMUHBys33//XXv37tXvv/+u1157TUlJSerRo4eGDh2qli1b2rvsffbZZwW2aOTK/UFj+/btatu2rX177pTud9xxhwYNGmTf3q5dO/3zn//UjBkzNGjQIPu5P2nSJB06dEiTJ0/Wli1bNHjwYDVq1Ejp6en6+eef9eabb6pGjRp5/t7Pnz+v7du3S8oJ7XFxcZo7d64kaezYsfZys2bN0nXXXacePXpowoQJcnd316uvvqr9+/fr3XfftQfeadOm2cfzPfnkk6pdu7befvttffrpp5o7d6596vj+/furTZs26tChg+rUqaNjx45p/vz5Cg8PV0REhKScc1HKCZzR0dFyc3NTixYtihVSci1atKjIMuPGjdPSpUt1ww036KmnnlJ4eLg+/fRTvfrqq/q///s/e4gsybld3L/pgpw5c0axsbF66KGHiv1agWqvQqfiAOAUcmdE27FjR55958+fNw0bNjQREREmKyvLGGPM3r17ze23326Cg4ONm5ubCQkJMT179nSYgWzy5MmmQ4cOplatWsbDw8M0adLEjBs3zj7jnjH5zxyYnp5uHn30URMcHGw8PT1Np06dzLZt2/LM4maMMd99953p0qWL8fHxMfXq1TPTpk0zb775Zp5Zw7Zu3Wo6d+5svL29TZ06dcw999xjdu3alWfWrkvrs23bNnPLLbeY8PBw4+HhYQIDA023bt3M6tWri/3eDh061EgyXbt2zbNvzZo1pm/fvqZevXrG3d3dBAcHm379+pmvvvqqyMcNDw83N9xwQ6Flcmcd/Ne//pXv/uJ8jsYY880335hOnToZDw8PExISYh577DHz73//u8hZB43JOX+efPJJExERYdzd3U1gYKDp2bOn2bp1q73Mnj17TNeuXY23t7eR5PAYv//+u3n44YdN48aNjZubm6ldu7a58sorzeOPP25SUlLs5X755RczcOBA4+vra/z8/MzAgQPN1q1biz3rYK6PP/7YSDK1a9c2aWlpefbPnj3bNGrUyHh4eJhWrVqZN954I9/zOL/z9ccffzS9e/c2/v7+pk6dOuahhx4yn376ab4zwG3evNnccMMNpnbt2sbNzc3Uq1fP3HDDDeaDDz4wxhiTlpZmxowZY9q2bWv8/f2Nl5eXadGihZk2bZo5d+5cka/zmmuuMf369bPfv3DhguncubMJCQkxZ86cyVM+IyPDXHHFFSY8PNwkJyc77Fu9erXp37+/qVu3rnF1dTV+fn6mXbt25tFHHzWHDh1yKHvprIMuLi4mLCzM9O3b12zatCnP83711VemZ8+exsfHx3h5eZlOnTqZTz75JE+5H374wfTv398EBAQYd3d3c8UVV+T53J977jnTpUsXExQUZNzd3U3Dhg3NqFGjzNGjRx3KTZkyxYSFhRkXF5cCZ+fLdfGsg4XJb2bNY8eOmaFDh5rAwEDj5uZmWrRoYf71r3/ZZwfMVZJzuzh/0wXNOrho0SLj5uZW6GyUABzZjGGJbwAA8JeVK1dq8ODBOnbsmMN4SFRf11xzjRo2bFjo2DIAjghaAADAgTFGXbp00ZVXXqmXX365oquDCrZlyxb17t1bBw4cUJMmTSq6OoDTYDIMAADgwGaz6Y033lBYWJiys7MrujqoYGfOnNHSpUsJWUAJ0aIFAAAAABajRQsAAAAALFZpgtaWLVvUv39/hYWFyWaz6aOPPrLvy8zM1KRJk3T55ZfLx8dHYWFhGjZsWJ41MS61ePFi2Wy2PLe0tLQyfjUAAAAAqrNKE7TOnTunK664It9Bt6mpqdq1a5emTp2qXbt2adWqVfrxxx910003Ffm4/v7+OnXqlMPN09OzLF4CAAAAAEiqRAsW9+3bV3379s13X0BAgNatW+ewbcGCBbrqqqt0/PhxNWzYsMDHtdlsCgkJKXY90tPTlZ6ebr+fnZ2tP/74Q4GBgfbFDwEAAABUP8YYnT17VmFhYXJxKbzNqtIErZJKSkqSzWZTzZo1Cy2XkpKi8PBwXbhwQe3atdPTTz+tyMjIAsvPmjVLM2bMsLi2AAAAAKqKEydOqH79+oWWqZSzDtpsNn344Ye6+eab892flpamq6++Wi1bttTy5csLfJzt27frp59+0uWXX67k5GS9+OKLWrt2rfbu3auIiIh8j7m0RSspKUkNGzbUiRMn5O/v/7deFwAAAADnlZycrAYNGigxMVEBAQGFlnW6Fq3MzEzdcccdys7O1quvvlpo2U6dOqlTp072+127dlX79u21YMECvfTSS/ke4+HhIQ8Pjzzb/f39CVoAAAAAijWkyKmCVmZmpm6//XbFxcVpw4YNJQ4+Li4u+sc//qHY2NgyqiEAAAAAVKJZB4uSG7JiY2O1fv16BQYGlvgxjDHas2ePQkNDy6CGAAAAAJCj0rRopaSk6KeffrLfj4uL0549e1S7dm2FhYVp0KBB2rVrl9asWaMLFy4oPj5eklS7dm25u7tLkoYNG6Z69epp1qxZkqQZM2aoU6dOioiIUHJysl566SXt2bNHr7zySvm/QAAAAADVRqUJWjt37lSPHj3s98ePHy9Jio6O1vTp07V69WpJUrt27RyO27hxo7p37y5JOn78uMM0i4mJibr33nsVHx+vgIAARUZGasuWLbrqqqvK9sUAAAAAqNYq5ayDlUlycrICAgKUlJTEZBgAAABANVaSbOA0Y7QAAAAAwFkQtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAi7lWdAUAAOUnKTVDCSkZSk7LlL+Xm4J83BXg7V7R1QIAoMohaAFANXEy8bwmrdynr2IT7NuiIoI0e2BbhdX0qsCaAQBQ9dB1EACqgaTUjDwhS5K2xCZo8sp9SkrNqKCaAQBQNRG0AKAaSEjJyBOycm2JTVBCCkELAAArEbQAoBpITsssdP/ZIvYDAICSIWgBQDXg7+lW6H6/IvYDAICSIWgBQDUQ5OuuqIigfPdFRQQpyJeZBwEAsBJBCwCqgQBvd80e2DZP2IqKCNKcgW2Z4h0AAIsxvTsAVBNhNb20YEikElIydDYtU36ebgryZR0tAADKAkELAKqRAG+CFQAA5YGugwAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWqzRBa8uWLerfv7/CwsJks9n00UcfOew3xmj69OkKCwuTl5eXunfvrv/9739FPu7KlSt12WWXycPDQ5dddpk+/PDDMnoFAAAAAJCj0gStc+fO6YorrtDLL7+c7/65c+fq+eef18svv6wdO3YoJCRE1113nc6ePVvgY27btk2DBw/W3Xffrb179+ruu+/W7bffrm+//basXgYAAAAAyGaMMRVdiUvZbDZ9+OGHuvnmmyXltGaFhYVp7NixmjRpkiQpPT1ddevW1Zw5c3Tffffl+ziDBw9WcnKy/vvf/9q39enTR7Vq1dK7776b7zHp6elKT0+3309OTlaDBg2UlJQkf39/i14hAAAAAGeTnJysgICAYmWDStOiVZi4uDjFx8erd+/e9m0eHh7q1q2btm7dWuBx27ZtczhGkq6//vpCj5k1a5YCAgLstwYNGvz9FwAAAACgWnGKoBUfHy9Jqlu3rsP2unXr2vcVdFxJj5kyZYqSkpLstxMnTvyNmgMAAACojlwrugIlYbPZHO4bY/Js+7vHeHh4yMPDo/SVBAAAAFDtOUWLVkhIiCTlaYk6ffp0nharS48r6TEAAAAA8Hc5RdBq3LixQkJCtG7dOvu2jIwMbd68WV26dCnwuM6dOzscI0lffPFFoccAAAAAwN9VaboOpqSk6KeffrLfj4uL0549e1S7dm01bNhQY8eO1bPPPquIiAhFRETo2Weflbe3t4YOHWo/ZtiwYapXr55mzZolSXrkkUcUFRWlOXPmaMCAAfr444+1fv16ff311+X++gAAAABUH5UmaO3cuVM9evSw3x8/frwkKTo6WosXL9bEiRN1/vx53X///frzzz/VsWNHffHFF/Lz87Mfc/z4cbm4/NVI16VLF7333nt64oknNHXqVDVt2lQrVqxQx44dy++FAQAAAKh2KuU6WpVJSebKBwAAAFB1Vbl1tAAAAADAmRC0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBirhVdAQAAgMouKTVDCSkZSk7LlL+Xm4J83BXg7V7R1QJQiRG0AAAACnEy8bwmrdynr2IT7NuiIoI0e2BbhdX0qsCaAajM6DoIAABQgKTUjDwhS5K2xCZo8sp9SkrNqKCaAajsCFoAAAAFSEjJyBOycm2JTVBCCkELQP6cJmg1atRINpstz+2BBx7It/ymTZvyLX/o0KFyrjkAAHBWyWmZhe4/W8R+ANWX04zR2rFjhy5cuGC/v3//fl133XW67bbbCj3u8OHD8vf3t9+vU6dOmdURAABULf6eboXu9ytiP4Dqy2mC1qUBafbs2WratKm6detW6HHBwcGqWbNmsZ8nPT1d6enp9vvJycklqicAAKg6gnzdFRURpC35dB+MighSkC8zDwLIn9N0HbxYRkaGli9frpEjR8pmsxVaNjIyUqGhoerVq5c2btxY5GPPmjVLAQEB9luDBg2sqjYAAHAyAd7umj2wraIighy2R0UEac7AtkzxDqBANmOMqehKlNT777+voUOH6vjx4woLC8u3zOHDh7VlyxZdeeWVSk9P17Jly7Rw4UJt2rRJUVFRBT52fi1aDRo0UFJSkkMXRAAAUH3krqN1Ni1Tfp5uCvJlHS2gOkpOTlZAQECxsoFTBq3rr79e7u7u+uSTT0p0XP/+/WWz2bR69epiH1OSNxMAAABA1VWSbOB0XQePHTum9evX65577inxsZ06dVJsbGwZ1AoAAAAA/uJ0QSsmJkbBwcG64YYbSnzs7t27FRoaWga1AgAAAIC/OM2sg5KUnZ2tmJgYRUdHy9XVsepTpkzRr7/+qqVLl0qS5s+fr0aNGql169b2yTNWrlyplStXVkTVAQAAAFQjThW01q9fr+PHj2vkyJF59p06dUrHjx+338/IyNCECRP066+/ysvLS61bt9ann36qfv36lWeVAQAAAFRDTjkZRnliMgwAAAAAUhWfDAMAAAAAKjuCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWMxpgtb06dNls9kcbiEhIYUes3nzZl155ZXy9PRUkyZNtHDhwnKqLQAAAIDqzLWiK1ASrVu31vr16+33a9SoUWDZuLg49evXT6NHj9by5cv1zTff6P7771edOnU0cODA8qguAAAAgGrKqYKWq6trka1YuRYuXKiGDRtq/vz5kqRWrVpp586dmjdvXqFBKz09Xenp6fb7ycnJf6vOAAAAAKofp+k6KEmxsbEKCwtT48aNdccdd+jnn38usOy2bdvUu3dvh23XX3+9du7cqczMzAKPmzVrlgICAuy3Bg0aWFZ/AAAAANWD0wStjh07aunSpfr888/1xhtvKD4+Xl26dNGZM2fyLR8fH6+6des6bKtbt66ysrKUkJBQ4PNMmTJFSUlJ9tuJEycsfR0AAAAAqj6n6TrYt29f+78vv/xyde7cWU2bNtWSJUs0fvz4fI+x2WwO940x+W6/mIeHhzw8PCyoMQAAAIDqymlatC7l4+Ojyy+/XLGxsfnuDwkJUXx8vMO206dPy9XVVYGBgeVRRQAAAADVlNMGrfT0dB08eFChoaH57u/cubPWrVvnsO2LL75Qhw4d5ObmVh5VBAAAAFBNOU3QmjBhgjZv3qy4uDh9++23GjRokJKTkxUdHS0pZ2zVsGHD7OXHjBmjY8eOafz48Tp48KDeeustLVq0SBMmTKiolwAAAACgmnCaMVq//PKLhgwZooSEBNWpU0edOnXS9u3bFR4eLkk6deqUjh8/bi/fuHFjrV27VuPGjdMrr7yisLAwvfTSS6yhBQAAAKDM2UzuDBHIV3JysgICApSUlCR/f/+Krg4AAACAClKSbOA0XQcBAAAAwFkQtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACzmWtEVAACgukpKzVBCSoaS0zLl7+WmIB93BXi7V3S1AAAWIGgBAFABTiae16SV+/RVbIJ9W1REkGYPbKuwml4VWDMAVRU/7pQvghYAAOUsKTUjT8iSpC2xCZq8cp8WDInkyw8AS/HjTvljjBYAAOUsISUjT8jKtSU2QQkpGeVcIwBVWVE/7iSlcs0pCwQtAADKWXJaZqH7zxaxHwBKgh93KgZBCwCAcubv6Vbofr8i9gNASfDjTsUgaAEAUM6CfN0VFRGU776oiCAF+TI+C4B1+HGnYhC0AAAoZwHe7po9sG2esBUVEaQ5A9syEQYAS/HjTsWwGWNMRVeiMktOTlZAQICSkpLk7+9f0dUBAFQhuVMtn03LlJ+nm4J8mWoZQNk4mXhek1fu05ZLZh2cM7CtQpl1sNhKkg2Y3h0AgAoS4E2wAlA+wmp6acGQSH7cKUcELQAAAKAa4Med8sUYLQAAAACwGEELAAAAACxG0AIAAAAAi1kStC5cuKA9e/bozz//tOLhAAAAAMCplSpojR07VosWLZKUE7K6deum9u3bq0GDBtq0aZOV9QMAAAAAp1OqoPWf//xHV1xxhSTpk08+UVxcnA4dOqSxY8fq8ccft7SCAAAAAOBsShW0EhISFBISIklau3atbrvtNjVv3lyjRo3SDz/8YGkFAQAAAMDZlCpo1a1bVwcOHNCFCxf02Wef6dprr5UkpaamqkaNGpZWEAAAAACcTakWLB4xYoRuv/12hYaGymaz6brrrpMkffvtt2rZsqWlFQQAAAAAZ1OqoDV9+nS1adNGJ06c0G233SYPDw9JUo0aNTR58mRLKwgAQHWSlJqhhJQMJadlyt/LTUE+7grwdq/oagEASshmjDEVXYnKLDk5WQEBAUpKSpK/v39FVwcAUIWdTDyvSSv36avYBPu2qIggzR7YVmE1vSqwZgAAqWTZoNgtWi+99FKxK/Dwww8Xu2xxzZo1S6tWrdKhQ4fk5eWlLl26aM6cOWrRokWBx2zatEk9evTIs/3gwYN0cQQAVCpJqRl5QpYkbYlN0OSV+7RgSKTTtmzRSgegOip20HrhhReKVc5ms5VJ0Nq8ebMeeOAB/eMf/1BWVpYef/xx9e7dWwcOHJCPj0+hxx4+fNghcdapU8fy+gEA8HckpGTkCVm5tsQmKCElwynDCa10AKqrYgetuLi4sqxHkT777DOH+zExMQoODtb333+vqKioQo8NDg5WzZo1i/U86enpSk9Pt99PTk4ucV0BACip5LTMQvefLWJ/ZVSVW+kAoCilmt69MkhKSpIk1a5du8iykZGRCg0NVa9evbRx48ZCy86aNUsBAQH2W4MGDSypLwAAhfH3dCt0v18R+yuj4rTSAShYUmqGjpxO0e7jf+rI7ylKSuVvxpmUatZBSfrll1+0evVqHT9+XBkZjh/6888//7crVhhjjMaPH6+rr75abdq0KbBcaGio/v3vf+vKK69Uenq6li1bpl69emnTpk0FtoJNmTJF48ePt99PTk4mbAEAylyQr7uiIoK0JZ9gEhURpCBf52v5qYqtdEB5odut8ytV0Pryyy910003qXHjxjp8+LDatGmjo0ePyhij9u3bW13HPB588EHt27dPX3/9daHlWrRo4TBZRufOnXXixAnNmzevwKDl4eFhn64eAIDyEuDtrtkD22ryyn0OYSsqIkhzBrZ1yi52VbGVDigPdLutGkoVtKZMmaJHH31UTz31lPz8/LRy5UoFBwfrzjvvVJ8+fayuo4OHHnpIq1ev1pYtW1S/fv0SH9+pUyctX768DGoGAMDfE1bTSwuGRCohJUNn0zLl5+mmIF/nnaGvKrbSAeWhqk6OU92UaozWwYMHFR0dLUlydXXV+fPn5evrq6eeekpz5syxtIK5jDF68MEHtWrVKm3YsEGNGzcu1ePs3r1boaGhFtcOAABrBHi7q2mwr9o1rKWmwb5O/WUqt5UuKiLIYbszt9IB5YFut1VDqVq0fHx87DPzhYWF6ciRI2rdurUkKSEh//T9dz3wwAN655139PHHH8vPz0/x8fGSpICAAHl55fRTnTJlin799VctXbpUkjR//nw1atRIrVu3VkZGhpYvX66VK1dq5cqVZVJHAADgqKq10gHlgW63VUOpglanTp30zTff6LLLLtMNN9ygRx99VD/88INWrVqlTp06WV1HSdJrr70mSerevbvD9piYGA0fPlySdOrUKR0/fty+LyMjQxMmTNCvv/4qLy8vtW7dWp9++qn69etXJnUEAAB5BXgTrICSoNtt1WAzxpiSHvTzzz8rJSVFbdu2VWpqqiZMmKCvv/5azZo10wsvvKDw8PCyqGuFSE5OVkBAgJKSkhwWPQYAAADKysnE8wVOjhPKrIMVpiTZoFRBqzohaAEAAKAiJKVm0O22kilJNij1OloAAAAAyg7dbp1bqYKWi4uLbDZbgfsvXLhQ6goBAAAAVUFui1RyWqb8vdwU5ENwqk5KFbQ+/PBDh/uZmZnavXu3lixZohkzZlhSMQAAAMBZnUw8n2fR4aiIIM0e2FZhjLGqFiwdo/XOO+9oxYoV+vjjj616yArHGC0AAACURFJqhh58d3e+iw5HRQRpwZBIWracVEmyQakWLC5Ix44dtX79eisfEgAAAHAqCSkZ+YYsSdoSm6CElIxyrhEqgmVB6/z581qwYIHq169v1UMCAAAATic5LbPQ/WeL2I+qoVRjtGrVquUwGYYxRmfPnpW3t7eWL19uWeUAAAAAZ+Pv6Vbofr8i9qNqKFXQeuGFFxyClouLi+rUqaOOHTuqVq1allUOAAAAcDZBvu6KighyWGw4V1REkIJ8GZ9VHbBgcRGYDAMAAAAldTLxvCav3OcQtqIigjRnYFuFMuug0yqTBYv37dtX7Aq0bdu22GUBAACAqiasppcWDIlUQkqGzqZlys/TTUG+rKNVnRQ7aLVr1042m025DWAsWAwAAAAULMC78gUrFlEuP8UOWnFxcfZ/7969WxMmTNBjjz2mzp07S5K2bdum5557TnPnzrW+lgAAAAD+FhZRLl+lGqN11VVXafr06erXr5/D9rVr12rq1Kn6/vvvLatgRWOMFgAA+DtoQXA+VfEzYxFla5TJGK2L/fDDD2rcuHGe7Y0bN9aBAwdK85AAAABVDi0IzqeqfmbFWUSZoGWtUi1Y3KpVK82cOVNpaWn2benp6Zo5c6ZatWplWeUAAACcVVJqRp4v7FLOl9rJK/cpKTWjgmqGglTlz4xFlMtfqVq0Fi5cqP79+6tBgwa64oorJEl79+6VzWbTmjVrLK0gAACAM6IFwflU5c+MRZTLX6mC1lVXXaW4uDgtX75chw4dkjFGgwcP1tChQ+Xj42N1HQEAAJwOLQjOpyp/ZiyiXP5KFbQkydvbW/fee6+VdQEAAKgyaEFwPlX5MwvwdtfsgW0LXETZWVvqKrNiB63Vq1erb9++cnNz0+rVqwste9NNN/3tigEAADgzWhCcT1X/zFhEuXwVe3p3FxcXxcfHKzg4WC4uBc+hYbPZqtSCxUzvDgAASutk4vkCWxBCSzmDXVWcerwyKYvPDFVHSbJBqdbRqk4IWgAA4O/IDUZWtCBU1anHKxsrPzNULRUStBITE1WzZk0rHqpSIWgBAIDKgAVngYpXkmxQqnW05syZoxUrVtjv33bbbapdu7bq1aunvXv3luYhAQAAUIjiTD0OoPIoVdB6/fXX1aBBA0nSunXrtH79en322Wfq27evHnvsMUsrCAAAgKo99ThQFZVqevdTp07Zg9aaNWt0++23q3fv3mrUqJE6duxoaQUBAABQtaceB6qiUrVo1apVSydOnJAkffbZZ7r22mslScaYKjXjIAAAQGWRO/V4fqrC1ONAVVOqoHXrrbdq6NChuu6663TmzBn17dtXkrRnzx41a9bM0goCAADgrwVnLw1bLDgLVE6l6jr4wgsvqFGjRjpx4oTmzp0rX19fSTldCu+//35LKwgAAIAcLDgLOA/W0SoC07sDAAAAkMphendJWrZsma6++mqFhYXp2LFjkqT58+fr448/Lu1DAgAAAECVUKqg9dprr2n8+PHq27evEhMT7RNg1KxZU/Pnz7eyfgAAAACUs2j1kdMp2n38Tx35PUVJqeW/dlplqIOzKNUYrQULFuiNN97QzTffrNmzZ9u3d+jQQRMmTLCscgAAAACkk4nnNWnlPodFq6MigjR7YFuF1fSqNnVwJqVq0YqLi1NkZGSe7R4eHjp37tzfrhQAAACAHEmpGXkCjiRtiU3Q5JX7yqVVqTLUwdmUKmg1btxYe/bsybP9v//9r1q1avV36wQAAACUq8rcJe702fQ8ASfXltgEJaSUfV0TUjIqvA7OplRdBx977DE98MADSktLkzFG3333nd599109++yzWrRokdV1BAAA1URSaoYSUjKUnJYpfy83BfkwdTmsd/F5FuDlJvcaLpry4Q+VskvcycTzOv5HaqFlzqZllnk9kot4jvKog7MpVdAaMWKEsrKyNHHiRKWmpmro0KGqV6+eFixYoGuuucbqOgIAgGqA8R8oD5eeZw/2bKbdx//UNz+dcSiX2yVuwZDICgv7ud31hndpVGg5P0+3Mq+LfxHPUR51cDalnt599OjROnbsmE6fPq34+Hh999132r17t5o1a2Zl/QAAQDXA+A+Uh/zOs8gGNfOErFwV3SUut7ve7hOJ6tosMN8yURFBCvIt+yAY5OuuqIigCq2DsylR0EpMTNSdd96pOnXqKCwsTC+99JJq166tV155Rc2aNdP27dv11ltvlVVdAQBAFcX4D5SH/M6z9KzsQo+pyC5xud313vo6TiO6Ns4Ttq6JCNKcgW3LpcUtwNtdswe2zRO2osqxDs6mRF0H//nPf2rLli2Kjo7WZ599pnHjxumzzz5TWlqa1q5dq27dupVVPQEAQBXG+A+Uh/zOMw/XwtsdKrJLXG53vdSMC3r43d0aeXVjjezaWOlZ2fJwdVGzOr4KLcdutWE1vbRgSKQSUjJ0Ni1Tfp5uCvJlHGVBShS0Pv30U8XExOjaa6/V/fffr2bNmql58+YsUgwAAP4Wxn+gPOR3nuV2y8uv+2BFd4nL7a63JTZBqRkX9PKGnxzqtmBI3uWWylqAN8GquErUdfDkyZO67LLLJElNmjSRp6en7rnnnjKpGAAAqD4Y/4HykN95ltst7+pLuuVVhi5xdNdzbjZjjClu4Ro1aig+Pl516tSRJPn5+Wnfvn1q3LhxmVXwUq+++qr+9a9/6dSpU2rdurXmz59f6EyHmzdv1vjx4/W///1PYWFhmjhxosaMGVPs50tOTlZAQICSkpLk7+9vxUsAAAD5OJl4XpNX7tOWS2YdnDOwbbl2j0LVlt95dl2rYE2/qbXSMrMrZZe43OnoK2PdqpuSZIMSBS0XFxf17dtXHh4ekqRPPvlEPXv2lI+Pj0O5VatWlaLaRVuxYoXuvvtuvfrqq+ratatef/11vfnmmzpw4IAaNmyYp3xcXJzatGmj0aNH67777tM333yj+++/X++++64GDhxYrOckaAEAUH74QonyUBHnGWvEVQ1lFrRGjBhRrHIxMTHFfcgS6dixo9q3b6/XXnvNvq1Vq1a6+eabNWvWrDzlJ02apNWrV+vgwYP2bWPGjNHevXu1bdu2Yj2n/c08eTL/N7NGDcnT86/7584V/GAuLpKXV+nKpqZKBX1UNpvk7V26sufPS9mFzLZzcYguSdm0NOnCBWvKenvn1FuS0tOlrCxrynp55bzPkpSRIWUWMtC6JGU9PXPOi5KWzczMKV8QDw/J1bXkZbOyct6Lgri7S25uJS974ULOZ1cQN7ec8iUtm52dc65ZUdbVNee9kHL+JlILWfCxJGVL8nfPNSL/slwjSl6Wa0TOv7lGlK4s14icf1fQNeJkujTpw/36KjZBbhcy5Xrhgro2C9TTA9rkba3lGpGjkl4jkpOTFRAWVrxGGOMk0tPTTY0aNcyqVasctj/88MMmKioq32OuueYa8/DDDztsW7VqlXF1dTUZGRn5HpOWlmaSkpLstxMnThhJJinn7c1769fP8QG8vfMvJxnTrZtj2aCggst26OBYNjy84LKXXeZY9rLLCi4bHu5YtkOHgssGBTmW7dat4LLe3o5l+/UruOylp92gQYWXTUn5q2x0dOFlT5/+q+z99xdeNi7ur7ITJhRedv/+v8pOm1Z42e+++6vs3LmFl9248a+yL79ceNk1a/4qGxNTeNn33/+r7PvvF142JuavsmvWFF725Zf/KrtxY+Fl5879q+x33xVedtq0v8ru31942QkT/iobF1d42fvv/6vs6dOFl42O/qtsSkrhZQcNMg4KK8s1IufGNeKvG9eInBvXiJwb14icWxW/Rkya8Y4Jn7TGhE9aY17oOqTwx+UakXOrpNeIJMlIMklJSaYopV6wuLwlJCTowoULqlu3rsP2unXrKj4+Pt9j4uPj8y2flZWlhIT81+qYNWuWAgIC7LcGDRpY8wIAAABQLX1/7M+KrgIqQIm6DlakkydPql69etq6das6d+5s3/7MM89o2bJlOnToUJ5jmjdvrhEjRmjKlCn2bd98842uvvpqnTp1SiEhIXmOSU9PV/pFTZ7Jyclq0KABXQdLWraKNfnTLSifsk7a5G9JWboF/YVrRMnLco3IUc2uEUmpGTqTkqGz6TljggJzx+dwjci/bBW6Ruw98adujtktY8spm9t1MNeKezuqbYNafx3ANSJHJb1GlKTrYInW0apIQUFB9lkPL3b69Ok8rVa5QkJC8i3v6uqqwMDAfI/x8PCwT/bhwMfH8Y+6IMUpU5qyF1/UrCzr5VV0mdKUvfg/DSvLenj8dcJbWdbd/a8/uooq6+b218XHyrKurn9dLK0sW6NG8c/hkpR1cSmbsjZb2ZSVKkdZrhE5uEaUvCzXiBxleI04memiSat/1FeXzKY4e2Bbhflccn5zjchRha4RvrWNPWRJUmYNN2XW+Ovv06d2zYI/S64RJS9b1teIwkL9pQ9f7JIVzN3dXVdeeaXWrVvnsH3dunXq0qVLvsd07tw5T/kvvvhCHTp0kFtxTy4AAIBSSkrN0KSV+xxCliRtiU3Q5JX7lJRaSKsCqgTWiKu+nCZoSdL48eP15ptv6q233tLBgwc1btw4HT9+3L4u1pQpUzRs2DB7+TFjxujYsWMaP368Dh48qLfeekuLFi3ShAkTKuolAACAaiQhJSNPyMq1JTZBCSkEraqORYerL6fpOihJgwcP1pkzZ/TUU0/p1KlTatOmjdauXavw8HBJ0qlTp3T8+HF7+caNG2vt2rUaN26cXnnlFYWFhemll14q9hpaAAAAf0dyWiHjaySdLWI/qoawml5aMCSSNeKqGaeZDKOisGAxAJQ9FvJEVXXkdIp6Pb+5wP1fju+mpsG+5VgjAH9HSbKBU7VoAQCqnpOJ5/OMYbFPFHDpQp6Ak8kdn7Mln+6DjM9BeeCHrIpDi1YRaNECgLKTlJqhB9/dne8YlqiIIC0YEskXAji9k4nnNXnlPoewlTs+J5QfE6CyC0P8kGU9WrQAAE6hOBMFELTg7Bifg8KUVRgqasZLZ/khy5lb5AhaAIAKw0QBqC4CvJ3nyyHKT1mGoarwQ5azt8g51fTuAICqxd+z8DUN/YrYDwDOrCyn/3f2H7Kqwhp0BC0AQIVhIU8A1VlZhiFn/yGrKqxBR9ACAFQYFvIEUJ2VZRhy9h+ynL1FTmKMFgCggjFRAIDqqiyn/8/9IaugGS8r+zXW2VvkJIIWAKASYKIAANVRccLQ35l1z5l/yKoKa9CxjlYRWEcLAAAAZSk3TF0ahpx91r2/qzKuQVeSbEDQKgJBCwAAAOWNBd1zFBRCKwoLFgMAAABOrCqsg2UFZ+5aTtACAACw0N8ZUwPkqgqz7lV3BC0AAACLVPcxNbBOWc26xw8B5YegBQAAYIGk1Iw8IUvK6eY1eeW+ajOmBtYoi1n3+CGgfLFgMQAAgAWKM6YGKC6rF3Qv6oeApFTOT6vRogUAAGABxtTA6m55Vq6DxeQa5Y+gBQAAYIGyGlMD51BW3fKsmnWPHwLKH10HAQAALJA7piY/pR1TY7Wk1AwdOZ2i3cf/1JHfU+guZhFn6JbHDwHljxYtAAAAC+SOqZm8cp/DBAalHVNjNSZCKDvO0C2vLCbXQOEIWgAAABaxckyNlZgRsWw5Q7e8yv5DQFVE0AIAALCQVWNqrOQMLS7OzFm65VXWHwKqKoIWAADARarigq7O0OLizJypW15l/CGgqiJoAQAA/H9VdRyTs7S4OCu65SE/BC0AAABV7XFMztTi4qzolodLEbQAAABUtccx0eJSPpypW15V7CJb2RC0AAAAVPXHMdHiglxVtYtsZcOCxQAAAKoe45gCvN3VNNhX7RrWUtNgX0JWNeQMiytXFQQtoBpKSs3QkdMp2n38Tx35PYWLKgDor3FM+WEcE6qK4nSRhTXoOghUM3QXAID8MY4J1UFV7yJbmRC0gGqkKs+oBQBWYBxT5cKEDdarDl1kKwuCFlCNVOUZtQDAKs40c1xVRg+MssFU/+WHMVpANUJ3AQCAM2DChrKT20X20vGIdJG1Hi1aQDVCdwEAgDOgB0bZoots+SBoAdUI3QUAAM6AHhhljy6yZY+ug0A1QncBAIAzoAcGqgJatIBqhu4CAIDKjh4YqApo0QKqoQBvdzUN9lW7hrXUNNiXkAUAqFTogYGqgBYtAECFY60cAJeiBwacHUELAFChWCsHQEGYsAHOjK6DAIAKw1o5AICqiqAFAKgwxVkrBwAAZ+QUQevo0aMaNWqUGjduLC8vLzVt2lTTpk1TRkbh/wEPHz5cNpvN4dapU6dyqjUAoCislQMAqKqcYozWoUOHlJ2drddff13NmjXT/v37NXr0aJ07d07z5s0r9Ng+ffooJibGft/dnX6+AFBZsFYOAKCqcoqg1adPH/Xp08d+v0mTJjp8+LBee+21IoOWh4eHQkJCyrqKAIBSYK0cAEBV5RRdB/OTlJSk2rVrF1lu06ZNCg4OVvPmzTV69GidPn260PLp6elKTk52uAEAygZr5QAAqiqbMcZUdCVK6siRI2rfvr2ee+453XPPPQWWW7FihXx9fRUeHq64uDhNnTpVWVlZ+v777+Xh4ZHvMdOnT9eMGTPybE9KSpK/v79lrwEA8JfcdbRYKwcAUJklJycrICCgWNmgQoNWQaHmYjt27FCHDh3s90+ePKlu3bqpW7duevPNN0v0fKdOnVJ4eLjee+893XrrrfmWSU9PV3p6uv1+cnKyGjRoQNACAAAAqrmSBK0KHaP14IMP6o477ii0TKNGjez/PnnypHr06KHOnTvr3//+d4mfLzQ0VOHh4YqNjS2wjIeHR4GtXQAAAABQHBUatIKCghQUFFR0QUm//vqrevTooSuvvFIxMTFycSn58LIzZ87oxIkTCg0NLfGxAAAAAFBcTjEZxsmTJ9W9e3c1aNBA8+bN0++//674+HjFx8c7lGvZsqU+/PBDSVJKSoomTJigbdu26ejRo9q0aZP69++voKAg3XLLLRXxMgAAAABUE04xvfsXX3yhn376ST/99JPq16/vsO/iIWaHDx9WUlKSJKlGjRr64YcftHTpUiUmJio0NFQ9evTQihUr5OfnV671BwAAcDa5k9Qkp2XK38tNQT5MUgOUhFPOOlieSjLgDQAAoCo4mXhek1bu01cXrXEXFRGk2QPbKqymVwXWzDkQUqsup5kMAwAAAJVLUmpGnpAlSVtiEzR55T4tGBJJaCgEIRW5nGKMFgAAAMpHQkpGnpCVa0tsghJSMsq5Rs6jqJCalMp7V50QtAAAAGCXnJZZ6P6zReyvzgipuBhdBwEAAGDn7+lW6H6/IvZXFaUZZ0VIxcUIWgAAALAL8nVXVESQtuTTMhMVEaQg36o/Pqu046wIqbgYXQcBAABgF+DtrtkD2yoqIshhe1REkOYMbFvlJ8L4O+OsckNqfqpLSMVfaNECAACAg7CaXlowJFIJKRk6m5YpP083BflWjynKizPOqqD3ITekTl65z6FFsLqEVDgiaAEAACCPAO/qEawu9XfHWVXnkApHBC0AAADg/7NinFV1DalwxBgtAAAA4P9jnBWsQtACAAAA/r/qPhkIrEPXQQAAAOAijLOCFQhaAAAAwCUYZ4W/i66DAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiM6d1RbSWlZighJUPJaZny93JTkA/TuAIAgKqF7zsVh6CFaulk4nlNWrlPX8Um2LdFRQRp9sC2CqvpVYE1AwAAsAbfdyoWXQdR7SSlZuS56EjSltgETV65T0mpGRVUMwAAAGvwfafiEbRQ7SSkZOS56OTaEpughBQuPAAAwLnxfafiEbRQ7SSnZRa6/2wR+wEAACo7vu9UPIIWqh1/T7dC9/sVsR8AAKCy4/tOxSNoodoJ8nVXVERQvvuiIoIU5MtMPAAAwLnxfafiEbRQ7QR4u2v2wLZ5Lj5REUGaM7AtU54CAACnx/edimczxpiKrkRllpycrICAACUlJcnf37+iqwML5a4rcTYtU36ebgryZV0JAABQtfB9x1olyQaso4VqK8CbCw0AAHBexVmMmO87FYegBQAAADgZFiOu/BijBQAAADgRFiN2DgQtAAAAwImwGLFzIGgBAAAAToTFiJ0DQQsAAABwIixG7BwIWgAAAIATYTFi50DQAgAAAJwIixE7B6Z3BwAAAJxMWE0vLRgSyWLElRhBCwAAAHBCLEZcudF1EAAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALCY0wStRo0ayWazOdwmT55c6DHGGE2fPl1hYWHy8vJS9+7d9b///a+cagwAAACgunKaoCVJTz31lE6dOmW/PfHEE4WWnzt3rp5//nm9/PLL2rFjh0JCQnTdddfp7Nmz5VRjAAAAANWRUwUtPz8/hYSE2G++vr4FljXGaP78+Xr88cd16623qk2bNlqyZIlSU1P1zjvvlGOtAQAAAFQ3ThW05syZo8DAQLVr107PPPOMMjIyCiwbFxen+Ph49e7d277Nw8ND3bp109atWws8Lj09XcnJyQ43AAAAACgJp1mw+JFHHlH79u1Vq1Ytfffdd5oyZYri4uL05ptv5ls+Pj5eklS3bl2H7XXr1tWxY8cKfJ5Zs2ZpxowZ1lUcAAAAQLVToS1a06dPzzPBxaW3nTt3SpLGjRunbt26qW3btrrnnnu0cOFCLVq0SGfOnCn0OWw2m8N9Y0yebRebMmWKkpKS7LcTJ078/RcKAAAAoFqp0BatBx98UHfccUehZRo1apTv9k6dOkmSfvrpJwUGBubZHxISIimnZSs0NNS+/fTp03lauS7m4eEhDw+PoqoOAAAAAAWq0KAVFBSkoKCgUh27e/duSXIIURdr3LixQkJCtG7dOkVGRkqSMjIytHnzZs2ZM6d0FQYAAACAYnCKyTC2bdumF154QXv27FFcXJzef/993XfffbrpppvUsGFDe7mWLVvqww8/lJTTZXDs2LF69tln9eGHH2r//v0aPny4vL29NXTo0Ip6KQAAAACqAaeYDMPDw0MrVqzQjBkzlJ6ervDwcI0ePVoTJ050KHf48GElJSXZ70+cOFHnz5/X/fffrz///FMdO3bUF198IT8/v/J+CQAAAACqEZsxxlR0JSqz5ORkBQQEKCkpSf7+/hVdHQAAAAAVpCTZwClatAAAAMpDUmqGElIylJyWKX8vNwX5uCvA272iq1Wp8B4BxUPQAgAAkHQy8bwmrdynr2IT7NuiIoI0e2BbhdX0qsCaVR68R0DxOcVkGAAAAGUpKTUjT4CQpC2xCZq8cp+SUjMqqGaVB+8RUDK0aAEAgGovISUjT4DItSU2QQkpGdW+exzvUf7oSomCELQAAEC1l5yWWej+s0Xsrw54j/KiKyUKQ9dBAABQ7fl7uhW636+I/dUB75EjulKiKAQtAABQ7QX5uisqIijffVERQQrypSsY75Gj4nSlRPVG0AIAANVegLe7Zg9smydIREUEac7Atoy5Ee/RpehKiaIwRgsAAEBSWE0vLRgSqYSUDJ1Ny5Sfp5uCfJnY4GK8R3+hKyWKQtACAAD4/wK8q2doKAneoxy5XSm35NN9sDp2pURedB0EAAAASoiulCgKLVoAAABAKdCVEoUhaAEAAAClRFdKFISugwAAAABgMYIWAAAAAFiMoAUAAAAAFmOMFgAAcApJqRlKSMlQclqm/L3cFOTD2BgAlRdBCwAAVHonE89r0sp9+uqiNYuiIoI0e2BbhdX0qsCaAUD+6DoIAAAqtaTUjDwhS5K2xCZo8sp9SkrNqKCaAUDBCFoAAKBSS0jJyBOycm2JTVBCCkELQOVD0AIAAJVaclpmofvPFrEfACoCQQsAAFRq/p5uhe73K2I/AFQEghYAAKjUgnzdFRURlO++qIggBfky8yCAyoegBQAAKrUAb3fNHtg2T9iKigjSnIFtmeIdQKXE9O4AAKDSC6vppQVDIpWQkqGzaZny83RTkC/raAGovAhaAADAKQR4E6wAOA+6DgIAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWc4qgtWnTJtlstnxvO3bsKPC44cOH5ynfqVOncqw5AAAAgOrItaIrUBxdunTRqVOnHLZNnTpV69evV4cOHQo9tk+fPoqJibHfd3d3L5M6AgAAAEAupwha7u7uCgkJsd/PzMzU6tWr9eCDD8pmsxV6rIeHh8OxAAAAAFDWnKLr4KVWr16thIQEDR8+vMiymzZtUnBwsJo3b67Ro0fr9OnThZZPT09XcnKyww0AAAAASsJmjDEVXYmS6tevnyRp7dq1hZZbsWKFfH19FR4erri4OE2dOlVZWVn6/vvv5eHhke8x06dP14wZM/JsT0pKkr+//9+vPAAAAACnlJycrICAgGJlgwoNWgWFmovt2LHDYRzWL7/8ovDwcL3//vsaOHBgiZ7v1KlTCg8P13vvvadbb7013zLp6elKT0+3309OTlaDBg0IWgAAAEA1V5KgVaFjtB588EHdcccdhZZp1KiRw/2YmBgFBgbqpptuKvHzhYaGKjw8XLGxsQWW8fDwKLC1CwAAAACKo0KDVlBQkIKCgopd3hijmJgYDRs2TG5ubiV+vjNnzujEiRMKDQ0t8bEAAAAAUFxONRnGhg0bFBcXp1GjRuW7v2XLlvrwww8lSSkpKZowYYK2bdumo0ePatOmTerfv7+CgoJ0yy23lGe1AQAAAFQzTjG9e65FixapS5cuatWqVb77Dx8+rKSkJElSjRo19MMPP2jp0qVKTExUaGioevTooRUrVsjPz688qw0AAACgmnHKWQfLU0kGvAEAAACoukqSDZyq6yAAAAAAOAOCFgAAAABYjKAFAAAAABYjaAEAAACAxQhaAAAAAGAxp5revTpLSs1QQkqGktMy5e/lpiAfdwV4u1d0tQAAAADkg6DlBE4mnteklfv0VWyCfVtURJBmD2yrsJpeFVgzAAAAAPmh62All5SakSdkSdKW2ARNXrlPSakZFVQzAAAAAAUhaFVyCSkZeUJWri2xCUpIIWgBAAAAlQ1Bq5JLTsssdP/ZIvYDAAAAKH8ErUrO39Ot0P1+RewHAAAAUP4IWpVckK+7oiKC8t0XFRGkIF9mHgQAAAAqG4JWJRfg7a7ZA9vmCVtREUGaM7AtU7wDAAAAlRDTuzuBsJpeWjAkUgkpGTqblik/TzcF+bKOFgAAAFBZEbScRIA3wQoAAABwFnQdBAAAAACLEbQAAAAAwGIELQAAAACwGEELAAAAACxG0AIAAAAAixG0AAAAAMBiBC0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtAAAAALAYQQsAAAAALEbQAgAAAACLEbQAAAAAwGKuFV2Bys4YI0lKTk6u4JoAAAAAqEi5mSA3IxSGoFWEs2fPSpIaNGhQwTUBAAAAUBmcPXtWAQEBhZaxmeLEsWosOztbJ0+elJ+fn2w2W0VXp1iSk5PVoEEDnThxQv7+/hVdHVQhnFsoK5xbKCucWygrnFvVkzFGZ8+eVVhYmFxcCh+FRYtWEVxcXFS/fv2Krkap+Pv784ePMsG5hbLCuYWywrmFssK5Vf0U1ZKVi8kwAAAAAMBiBC0AAAAAsBhBqwry8PDQtGnT5OHhUdFVQRXDuYWywrmFssK5hbLCuYWiMBkGAAAAAFiMFi0AAAAAsBhBCwAAAAAsRtACAAAAAIsRtAAAAADAYgQtJ9aoUSPZbLY8twceeECSNHz48Dz7OnXqVMG1RmWXlZWlJ554Qo0bN5aXl5eaNGmip556StnZ2fYyxhhNnz5dYWFh8vLyUvfu3fW///2vAmsNZ1Ccc4vrFkrr7NmzGjt2rMLDw+Xl5aUuXbpox44d9v1ct1BaRZ1bXLdQENeKrgBKb8eOHbpw4YL9/v79+3Xdddfptttus2/r06ePYmJi7Pfd3d3LtY5wPnPmzNHChQu1ZMkStW7dWjt37tSIESMUEBCgRx55RJI0d+5cPf/881q8eLGaN2+umTNn6rrrrtPhw4fl5+dXwa8AlVVxzi2J6xZK55577tH+/fu1bNkyhYWFafny5br22mt14MAB1atXj+sWSq2oc0viuoX8Mb17FTJ27FitWbNGsbGxstlsGj58uBITE/XRRx9VdNXgRG688UbVrVtXixYtsm8bOHCgvL29tWzZMhljFBYWprFjx2rSpEmSpPT0dNWtW1dz5szRfffdV1FVRyVX1LkliesWSuX8+fPy8/PTxx9/rBtuuMG+vV27drrxxhv19NNPc91CqRR1bs2cOZPrFgpE18EqIiMjQ8uXL9fIkSNls9ns2zdt2qTg4GA1b95co0eP1unTpyuwlnAGV199tb788kv9+OOPkqS9e/fq66+/Vr9+/SRJcXFxio+PV+/eve3HeHh4qFu3btq6dWuF1BnOoahzKxfXLZRUVlaWLly4IE9PT4ftXl5e+vrrr7luodSKOrdycd1Cfug6WEV89NFHSkxM1PDhw+3b+vbtq9tuu03h4eGKi4vT1KlT1bNnT33//fesYo4CTZo0SUlJSWrZsqVq1KihCxcu6JlnntGQIUMkSfHx8ZKkunXrOhxXt25dHTt2rNzrC+dR1Lklcd1C6fj5+alz5856+umn1apVK9WtW1fvvvuuvv32W0VERHDdQqkVdW5JXLdQMIJWFbFo0SL17dtXYWFh9m2DBw+2/7tNmzbq0KGDwsPD9emnn+rWW2+tiGrCCaxYsULLly/XO++8o9atW2vPnj0aO3aswsLCFB0dbS93ccuplDPQ/NJtwMWKc25x3UJpLVu2TCNHjlS9evVUo0YNtW/fXkOHDtWuXbvsZbhuoTSKOre4bqEgBK0q4NixY1q/fr1WrVpVaLnQ0FCFh4crNja2nGoGZ/TYY49p8uTJuuOOOyRJl19+uY4dO6ZZs2YpOjpaISEhknJatkJDQ+3HnT59Os+vxcDFijq38sN1C8XVtGlTbd68WefOnVNycrJCQ0M1ePBgNW7cmOsW/pbCzq38cN1CLsZoVQExMTEKDg52GKSZnzNnzujEiRMO/8kAl0pNTZWLi+OloUaNGvYpuHO/tKxbt86+PyMjQ5s3b1aXLl3Kta5wLkWdW/nhuoWS8vHxUWhoqP788099/vnnGjBgANctWCK/cys/XLeQixYtJ5edna2YmBhFR0fL1fWvjzMlJUXTp0/XwIEDFRoaqqNHj+qf//yngoKCdMstt1RgjVHZ9e/fX88884waNmyo1q1ba/fu3Xr++ec1cuRISTldb8aOHatnn31WERERioiI0LPPPitvb28NHTq0gmuPyqyoc4vrFv6Ozz//XMYYtWjRQj/99JMee+wxtWjRQiNGjOC6hb+lsHOL6xYKZeDUPv/8cyPJHD582GF7amqq6d27t6lTp45xc3MzDRs2NNHR0eb48eMVVFM4i+TkZPPII4+Yhg0bGk9PT9OkSRPz+OOPm/T0dHuZ7OxsM23aNBMSEmI8PDxMVFSU+eGHHyqw1nAGRZ1bXLfwd6xYscI0adLEuLu7m5CQEPPAAw+YxMRE+36uWyitws4trlsoDOtoAQAAAIDFGKMFAAAAABYjaAEAAACAxQhaAAAAAGAxghYAAAAAWIygBQAAAAAWI2gBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUA1cz06dPVrl07+/3hw4fr5ptvLvd6HD16VDabTXv27Cn35y5K9+7dNXbs2HJ5LpvNpo8++qhcnquy2bBhg1q2bKns7OxSP8aaNWsUGRn5tx4DAMoCQQsAKoHhw4fLZrPJZrPJzc1NTZo00YQJE3Tu3Lkyf+4XX3xRixcvLlbZighHP/30k0aOHKmGDRvKw8ND9erVU69evfT2228rKyur3Orxd10acHOdOnVKffv2LdPnXrx4sf38stlsqlu3rvr376///e9/JX6cmjVrWlaviRMn6vHHH5eLS87Xkd27dysyMlK+vr666aab9Oeff9rLZmVlqX379tqxY4fDY9x4442y2Wx65513LKsXAFiBoAUAlUSfPn106tQp/fzzz5o5c6ZeffVVTZgwId+ymZmZlj1vQECApV+erfTdd9+pffv2OnjwoF555RXt379fa9as0ciRI7Vw4cJCg4KV71FZCgkJkYeHR5k/j7+/v06dOqWTJ0/q008/1blz53TDDTcoIyOjzJ87P1u3blVsbKxuu+02+7Z77rlHPXv21K5du5SYmKhnn33Wvm/evHm6+uqr9Y9//CPPY40YMUILFiwol3oDQHERtACgkvDw8FBISIgaNGigoUOH6s4777R3KcttDXnrrbfUpEkTeXh4yBijpKQk3XvvvQoODpa/v7969uypvXv3Ojzu7NmzVbduXfn5+WnUqFFKS0tz2H9p18Hs7GzNmTNHzZo1k4eHhxo2bKhnnnlGktS4cWNJUmRkpGw2m7p3724/LiYmRq1atZKnp6datmypV1991eF5vvvuO0VGRsrT01MdOnTQ7t27C30/jDEaPny4mjdvrm+++Ub9+/dXRESEIiMjdeedd+qrr75S27ZtJf3V0vb++++re/fu8vT01PLly3XmzBkNGTJE9evXl7e3ty6//HK9++67Ds9z7tw5DRs2TL6+vgoNDdVzzz2Xpy75de+rWbOmQ0vgpEmT1Lx5c3l7e6tJkyaaOnWqPewtXrxYM2bM0N69e+2tSrnHXvrYP/zwg3r27CkvLy8FBgbq3nvvVUpKin1/7uc1b948hYaGKjAwUA888ECRwdJmsykkJEShoaHq0KGDxo0bp2PHjunw4cP2Ms8//7wuv/xy+fj4qEGDBrr//vvtz71p0yaNGDFCSUlJ9tcwffp0SVJGRoYmTpyoevXqycfHRx07dtSmTZsKrc97772n3r17y9PT077t4MGDGj16tJo3b64hQ4bowIEDkqSff/5Zb731lv08vNRNN92k7777Tj///HOhzwkA5YmgBQCVlJeXl8OX559++knvv/++Vq5cae+6d8MNNyg+Pl5r167V999/r/bt26tXr176448/JEnvv/++pk2bpmeeeUY7d+5UaGhongB0qSlTpmjOnDmaOnWqDhw4oHfeeUd169aVlBOWJGn9+vU6deqUVq1aJUl644039Pjjj+uZZ57RwYMH9eyzz2rq1KlasmSJpJwwc+ONN6pFixb6/vvvNX369AJb63Lt2bNHBw8e1IQJE+xdyy5ls9kc7k+aNEkPP/ywDh48qOuvv15paWm68sortWbNGu3fv1/33nuv7r77bn377bf2Yx577DFt3LhRH374ob744gtt2rRJ33//faF1y4+fn58WL16sAwcO6MUXX9Qbb7yhF154QZI0ePBgPfroo2rdurVOnTqlU6dOafDgwXkeIzU1VX369FGtWrW0Y8cOffDBB1q/fr0efPBBh3IbN27UkSNHtHHjRi1ZskSLFy8udvdPSUpMTLR3tXNzc7Nvd3Fx0UsvvaT9+/dryZIl2rBhgyZOnChJ6tKli+bPn29vGTt16pT9MxwxYoS++eYbvffee9q3b59uu+029enTR7GxsQXWYcuWLerQoYPDtiuuuELr1q1TVlaWvvzyS3uQHjNmjObOnSs/P798Hys8PFzBwcH66quviv0eAECZMwCAChcdHW0GDBhgv//tt9+awMBAc/vttxtjjJk2bZpxc3Mzp0+ftpf58ssvjb+/v0lLS3N4rKZNm5rXX3/dGGNM586dzZgxYxz2d+zY0VxxxRX5PndycrLx8PAwb7zxRr71jIuLM5LM7t27HbY3aNDAvPPOOw7bnn76adO5c2djjDGvv/66qV27tjl37px9/2uvvZbvY+V67733jCSza9cu+7bffvvN+Pj42G+vvPKKQ73mz5+f72NdrF+/fubRRx81xhhz9uxZ4+7ubt577z37/jNnzhgvLy/zyCOP2LdJMh9++KHD4wQEBJiYmJgCn2fu3LnmyiuvtN+fNm2aw/ue32P/+9//NrVq1TIpKSn2/Z9++qlxcXEx8fHxxpiczys8PNxkZWXZy9x2221m8ODBBdYlJibGSDI+Pj7G29vbSDKSzE033VTgMcYY8/7775vAwECHxwkICHAo89NPPxmbzWZ+/fVXh+29evUyU6ZMKfCxAwICzNKlSx227d+/30RFRZmGDRuaIUOGmKSkJLNkyRIzYMAA88svv5jevXubpk2bmscffzzP40VGRprp06cX+noAoDy5VljCAwA4WLNmjXx9fZWVlaXMzEwNGDDAYdxJeHi46tSpY7///fffKyUlRYGBgQ6Pc/78eR05ckRSTlesMWPGOOzv3LmzNm7cmG8dDh48qPT0dPXq1avY9f7999914sQJjRo1SqNHj7Zvz8rKUkBAgP1xr7jiCnl7ezvUozgubrUKDAy0t+Z17949z/iiS1tILly4oNmzZ2vFihX69ddflZ6ervT0dPn4+EiSjhw5ooyMDIe61K5dWy1atChW3S72n//8R/Pnz9dPP/2klJQUZWVlyd/fv0SPkfs+5dZPkrp27ars7GwdPnzY3rLYunVr1ahRw14mNDRUP/zwQ6GP7efnp127dikrK0ubN2/Wv/71Ly1cuNChzMaNG/Xss8/qwIEDSk5OVlZWltLS0nTu3DmHOl1s165dMsaoefPmDtvT09PznJsXO3/+vEO3wdzXtXnzZvv9M2fOaPr06dqyZYseeughde3aVatWrdI//vEPdezYUf3797eX9fLyUmpqaqHvAQCUJ4IWAFQSPXr00GuvvSY3NzeFhYU5dOmSlOeLbnZ2tkJDQ/MdC1PayS28vLxKfEzutNpvvPGGOnbs6LAvNwwYY0r8uBEREZKkQ4cO2Wfrq1Gjhpo1ayZJcnXN+1/Ype/Rc889pxdeeEHz58+3jz0aO3asPaAVt142my1P2Yu7dW7fvl133HGHZsyYoeuvv14BAQF677338h3vVRhjTJ7ukBfXIdel54bNZityenMXFxf7e9eyZUvFx8dr8ODB2rJliyTp2LFj6tevn8aMGaOnn35atWvX1tdff61Ro0YVOv4rOztbNWrU0Pfff+8Q/iTJ19e3wOOCgoIcZhXMz7hx4zR27FjVr19fmzZt0syZM+Xj46MbbrhBmzZtcghaf/zxh8MPEQBQ0RijBQCVhI+Pj5o1a6bw8PA8X6Tz0759e8XHx8vV1VXNmjVzuAUFBUmSWrVqpe3btzscd+n9i0VERMjLy0tffvllvvvd3d0l5bQU5apbt67q1aunn3/+OU89cifPuOyyy7R3716dP3++WPWQcibcaNmypebNm1fqNZK++uorDRgwQHfddZeuuOIKNWnSxGHcULNmzeTm5uZQlz///FM//vijw+PUqVNHp06dst+PjY11aD355ptvFB4erscff1wdOnRQRESEjh075vAY7u7uDu9bfi677DLt2bPHYVr/b775Ri4uLnlajP6ucePGae/evfrwww8lSTt37lRWVpaee+45derUSc2bN9fJkyeLfA2RkZG6cOGCTp8+nefzDwkJKfD5IyMj7ZNd5OfLL7/UoUOH7OPTLly4YA98mZmZDvVIS0vTkSNHFBkZWbI3AQDKEEELAJzUtddeq86dO+vmm2/W559/rqNHj2rr1q164okntHPnTknSI488orfeektvvfWWfvzxR02bNq3QKdE9PT01adIkTZw4UUuXLtWRI0e0fft2LVq0SJIUHBwsLy8vffbZZ/rtt9+UlJQkKWdWxFmzZunFF1/Ujz/+qB9++EExMTF6/vnnJUlDhw6Vi4uLRo0apQMHDmjt2rWaN29eoa/PZrMpJiZGhw8fVteuXbV69WrFxsbqwIEDWrhwoX7//fc8LSiXatasmdatW6etW7fq4MGDuu+++xQfH2/f7+vrq1GjRumxxx7Tl19+qf3792v48OF5Jt/o2bOnXn75Ze3atUs7d+7UmDFjHMJws2bNdPz4cb333ns6cuSIXnrpJXuAydWoUSPFxcVpz549SkhIUHp6ep763nnnnfL09FR0dLT279+vjRs36qGHHtLdd99t7zZoFX9/f91zzz2aNm2ajDFq2rSpsrKytGDBAv38889atmxZnq6FjRo1UkpKir788kslJCQoNTVVzZs315133qlhw4Zp1apViouL044dOzRnzhytXbu2wOe//vrr9fXXX+e77/z583rggQf073//2/5ZdO3aVa+88or27t2rlStXqmvXrvby27dvl4eHR7G7owJAuajIAWIAgByXToZxqYImUkhOTjYPPfSQCQsLM25ubqZBgwbmzjvvNMePH7eXeeaZZ0xQUJDx9fU10dHRZuLEiQVOhmGMMRcuXDAzZ8404eHhxs3NzTRs2NA8++yz9v1vvPGGadCggXFxcTHdunWzb3/77bdNu3btjLu7u6lVq5aJiooyq1atsu/ftm2bueKKK4y7u7tp166dWblyZaGTYeQ6fPiwiY6ONvXr1zeurq4mICDAREVFmddff91kZmYaYwqepOPMmTNmwIABxtfX1wQHB5snnnjCDBs2zOH1nj171tx1113G29vb1K1b18ydO9d069bNYTKMX3/91fTu3dv4+PiYiIgIs3bt2jyTYTz22GMmMDDQ+Pr6msGDB5sXXnjBYeKItLQ0M3DgQFOzZk0jyX6sLploY9++faZHjx7G09PT1K5d24wePdqcPXu2wM/LGGMeeeQRh8/iUvlNYmGMMceOHTOurq5mxYoVxhhjnn/+eRMaGmq8vLzM9ddfb5YuXWokmT///NN+zJgxY0xgYKCRZKZNm2aMMSYjI8M8+eSTplGjRsbNzc2EhISYW265xezbt6/AOv3xxx/Gy8vLHDp0KM++yZMn2ycsyRUbG2v+8Y9/GH9/fzNmzBhz4cIF+757773X3HfffQU+FwBUBJsxpeg4DwAA8DdNnDhRSUlJev3110v9GL///rtatmypnTt32ruqAkBlQNdBAABQIR5//HGFh4cXOXatMHFxcXr11VcJWQAqHVq0AAAAAMBitGgBAAAAgMUIWgAAAABgMYIWAAAAAFiMoAUAAAAAFiNoAQAAAIDFCFoAAAAAYDGCFgAAAABYjKAFAAAAABYjaAEAAACAxf4fmV63xoraHv4AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#check residuals for xgboost model\n",
+    "residuals_xgb = y_test - y_pred_test_xgb\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "sns.scatterplot(x=y_pred_test_xgb, y=residuals_xgb)\n",
+    "plt.axhline(0, color='red', linestyle='--')\n",
+    "plt.title(\"Residuals vs Predicted Values (XGBoost Model)\")\n",
+    "plt.xlabel(\"Predicted Graduation Rate (%)\")\n",
+    "plt.ylabel(\"Residuals\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2c219d0",
+   "metadata": {},
+   "source": [
+    "### Different Regression Models\n",
+    "\n",
+    "##### Support Vector Regression(SVR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 412,
+   "id": "d8a1bc84",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SVR Cross-validation MSE scores: [39.65765664 30.06950472 20.26533655 23.51904392 18.64086031]\n",
+      "Mean MSE (SVR): 26.43048042847091\n",
+      "Standard Deviation of MSE (SVR): 7.685887474836358\n"
+     ]
+    }
+   ],
+   "source": [
+    "#check SVR model for cross validation\n",
+    "from sklearn.svm import SVR\n",
+    "\n",
+    "svr_model = SVR(kernel='rbf')\n",
+    "svr_cv_scores = cross_val_score(svr_model, X_train_scaled, y_train, cv=5, scoring='neg_mean_squared_error')\n",
+    "\n",
+    "# Convert negative MSE scores to positive\n",
+    "svr_cv_scores = -svr_cv_scores\n",
+    "\n",
+    "print(\"SVR Cross-validation MSE scores:\", svr_cv_scores)\n",
+    "print(\"Mean MSE (SVR):\", np.mean(svr_cv_scores))\n",
+    "print(\"Standard Deviation of MSE (SVR):\", np.std(svr_cv_scores))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 413,
+   "id": "a3bfe421",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train MSE (SVR): 21.12222028625674\n",
+      "Train R2 (SVR): 0.5686642744569583\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Check svr model metrics for training set\n",
+    "svr_model.fit(X_train_scaled, y_train)\n",
+    "y_train_pred_svr = svr_model.predict(X_train_scaled)\n",
+    "\n",
+    "# Training set metrics for SVR\n",
+    "print(\"Train MSE (SVR):\", mean_squared_error(y_train, y_train_pred_svr))\n",
+    "print(\"Train R2 (SVR):\", r2_score(y_train, y_train_pred_svr))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 414,
+   "id": "0adff384",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test MSE (SVR): 23.53471614154744\n",
+      "Test R2 (SVR): 0.4533305568068813\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Create SVR model\n",
+    "from sklearn.svm import SVR\n",
+    "\n",
+    "# Initialize the SVR model\n",
+    "svr_model = SVR(kernel='rbf', C=1.0, epsilon=0.1)\n",
+    "\n",
+    "# Fit the model\n",
+    "svr_model.fit(X_train_scaled, y_train)\n",
+    "\n",
+    "# Predict on the test set\n",
+    "y_pred_test_svr = svr_model.predict(X_test_scaled)\n",
+    "\n",
+    "# Calculate metrics on test set\n",
+    "test_mse_svr = mean_squared_error(y_test, y_pred_test_svr)\n",
+    "test_r2_svr = r2_score(y_test, y_pred_test_svr)\n",
+    "\n",
+    "print(\"Test MSE (SVR):\", test_mse_svr)\n",
+    "print(\"Test R2 (SVR):\", test_r2_svr)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 415,
+   "id": "123d1a07",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1UAAAIhCAYAAACmO5ClAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYP5JREFUeJzt3XmcjfX///HnMWbfLIMxjLGNrZKJspUlfcjaRrKESPlIRSF9FVJoTynxUbYW0UdJkhZZKoRs+VChCcXEiBljzP7+/eE3J2f2mWtmzpk5j/vtdm4357re5zqvc64zl/M81/v9vmzGGCMAAAAAQJFUcHYBAAAAAFCWEaoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAJSYxYsXy2az2W8VK1ZUzZo1ddddd+nQoUMl9rzTpk2TzWYrUNu6detq2LBhJVZLYetxtrp16zrss4CAALVu3VpLly4tlefP/Mz8/vvv9mWdOnVSp06dCr2tmTNnatWqVcVWW6bff/9dNptNixcvzrXNuHHjZLPZ9PPPP+faZvLkybLZbNq1a1eBn7s0Pq9WTZ8+Xc2aNVNGRoZ92ZkzZ/T444+rWbNm8vf3V3BwsJo0aaK7775b+/btkyTddttt8vX11blz53Ld9qBBg+Tp6am//vpLkhw+qzabTUFBQWrXrp2WLVtWoFoz96XNZtO0adNybDN8+HB7m+JU1M+1lP1z8Ouvv8rLy6tQnyUAxYtQBaDELVq0SFu3btXXX3+tMWPGaPXq1br++ut19uzZEnm+e++9V1u3bi2RbbuD9u3ba+vWrdq6das95AwdOlRvvvmmU+qZO3eu5s6dW+jHlVSoKogRI0ZIkhYuXJjj+oyMDC1dulQtWrTQNddcU5qllagTJ07o+eef1/Tp01WhwqWvGAkJCWrTpo0WL16se++9V6tXr9Z7772n++67T9HR0dqzZ4+kS+9ZUlKS3n///Ry3HRcXp48//li9evVSjRo17Mv79u2rrVu3asuWLZo3b57i4+M1cODAXLeTk8DAQC1evNghCGbW/uGHHyooKKiQ70TpatSokQYNGqRx48Y5uxTAbRGqAJS4K6+8Um3atFGnTp00efJkTZo0SadOnSqxL7y1a9dWmzZtSmTb7qBSpUpq06aN2rRpo759+2rdunUKCgrSyy+/nOtj0tPTlZycXCL1NGvWTM2aNSuRbZeUK6+8Utddd53eeecdpaWlZVv/5Zdf6o8//rCHr/Li1VdfVaVKlXT77bfbl3344Yc6fPiw3n//fT3yyCPq0qWLevXqpUceeUTfffedBg8eLEnq3r27wsLCcg2iy5Yt08WLF7O9ZzVq1FCbNm3Utm1bDRw4UJ999pkkaf78+QWuu3///jp69KjWr1/vsHz58uVKT09Xnz59CrwtZxkzZow2b96sLVu2OLsUwC0RqgCUulatWkmSvQtPpp07d6pPnz6qUqWKfHx8FBUVpRUrVji0SUxM1Pjx41WvXj35+PioSpUqatWqlUN3n5y626WmpmrixIkKDQ2Vn5+frr/+em3fvj1bbbl11cupW9ry5cvVtWtX1axZU76+vmratKkmTZqkCxcu5PsefPPNN+rUqZOqVq0qX19f1alTR3fccYcSExNzfcytt96qiIiIbL+mS1Lr1q0dznh8+OGHat26tYKDg+Xn56f69etr+PDh+daVk0qVKqlx48Y6evSopH+6TD3//PN65plnVK9ePXl7e2vDhg2SCrYfJWnbtm1q3769fHx8FBYWpscff1ypqanZ2uXUTSo5OVnTp09X06ZN5ePjo6pVq6pz5872L5Q2m00XLlzQkiVL7F23Lt9GTEyM7r//ftWuXVteXl6qV6+ennrqqWwB6MSJE7rzzjsVGBio4OBg9e/fXzExMQV630aMGKGYmBh9/vnn2dYtWrRI3t7eGjRokJKSkvToo4+qRYsWCg4OVpUqVdS2bVt98skn+T5HTp9LSdq4caNsNps2btzosPzrr79Wly5dFBQUJD8/P7Vv3z5bkDh9+rTuu+8+hYeHy9vbW9WqVVP79u319ddf51lLSkqK3n77bQ0cONB+lkq61PVPkmrWrJnj4zLbenh4aOjQofrxxx/1008/ZWu3aNEi1axZU927d8+zjoiICFWrVi3b8SUvjRs3Vrt27bIFuoULF+r2229XcHBwtsdkZGTo+eefV5MmTeTt7a3q1atryJAh+uOPPxzaGWP0/PPPKyIiQj4+Prrmmmty/ExIUnx8vP345uXlpVq1amns2LEFOqa0bNlSTZs21bx58wr8ugEUH0IVgFIXHR0t6VKXlUwbNmxQ+/btde7cOc2bN0+ffPKJWrRoof79+zuMXXnkkUf05ptv6qGHHtK6dev0zjvvqF+/fvYvbrkZOXKkXnzxRQ0ZMkSffPKJ7rjjDt1+++2WuiAeOnRIPXr00Ntvv61169Zp7NixWrFihXr37p3n437//Xf17NlTXl5eWrhwodatW6dnn31W/v7+SklJyfVxw4cP17Fjx/TNN984LP/555+1fft23XPPPZKkrVu3qn///qpfv74++OADffbZZ5oyZUqOZ0wKIjU1VUePHlW1atUclr/22mv65ptv9OKLL+rzzz9XkyZNCrwfDxw4oC5duujcuXNavHix5s2bp927d+uZZ57Jt560tDR1795dTz/9tHr16qWPP/5YixcvVrt27XTs2DH7e+Dr66sePXrYuzJmdiGMiYnRddddpy+++EJTpkzR559/rhEjRmjWrFkaOXKk/XkuXryom266SV9++aVmzZqlDz/8UKGhoerfv3+B3rcBAwbIz88v2xf1s2fP6pNPPtFtt92mypUrKzk5WX///bfGjx+vVatWadmyZbr++ut1++23F+tYtnfffVddu3ZVUFCQlixZohUrVqhKlSrq1q2bQ7C6++67tWrVKk2ZMkVffvml3nrrLd100035/o398MMPOnPmjDp37uywvG3btpKkIUOGaNWqVXluJ3P8Utb37MCBA9q+fbuGDh0qDw+PPOuIi4vT33//7XB8KYgRI0Zo1apV9mPCL7/8oi1btuR6NvHf//63HnvsMf3rX//S6tWr9fTTT2vdunVq166dYmNj7e2eeuope7tVq1bp3//+t0aOHKlffvnFYXuJiYnq2LGjlixZooceekiff/65HnvsMS1evFh9+vSRMSbf19CpUyd9/vnnBWoLoJgZACghixYtMpLMtm3bTGpqqjl//rxZt26dCQ0NNR06dDCpqan2tk2aNDFRUVEOy4wxplevXqZmzZomPT3dGGPMlVdeaW699dY8n3fq1Knm8sPbwYMHjSQzbtw4h3bvvfeekWSGDh2a62Ozvpbo6OgcnzMjI8OkpqaaTZs2GUlm7969uW7zv//9r5Fk9uzZk+fryCo1NdXUqFHDDBw40GH5xIkTjZeXl4mNjTXGGPPiiy8aSebcuXOF2r4xxkRERJgePXqY1NRUk5qaaqKjo83QoUONJDNhwgRjjDHR0dFGkmnQoIFJSUlxeHxB92P//v2Nr6+viYmJsbdJS0szTZo0yfY+d+zY0XTs2NF+f+nSpUaSWbBgQZ6vxd/f32HfZrr//vtNQECAOXr0qMPyzPftf//7nzHGmDfffNNIMp988olDu5EjRxpJZtGiRXk+vzHGDB061Hh6epq//vrLvmzOnDlGkvnqq69yfExaWppJTU01I0aMMFFRUQ7rIiIiHF5Tbp/LDRs2GElmw4YNxhhjLly4YKpUqWJ69+7t0C49Pd1cffXV5rrrrrMvCwgIMGPHjs33tWX13HPPGUkO+zTT9OnTjZeXl5FkJJl69eqZUaNGOfydZOrYsaMJCQlx+Gw9+uijRpL59ddfHdpKMqNHjzapqakmJSXF/Prrr6ZPnz4mMDDQ7Ny5M9+aMz/LL7zwgjl//rwJCAgwr7/+ujHGmAkTJph69eqZjIwM88ADD+R4TBk9erTD9n744Qcjyfzf//2fMcaYs2fPGh8fH3Pbbbc5tPv++++NJIfP9axZs0yFChXMjh07HNpmHi/Wrl1rX5b1c5BpwYIFRpI5ePBgvq8dQPHiTBWAEtemTRt5enoqMDBQN998sypXrqxPPvlEFStWlCQdPnxYP//8swYNGiTp0pmIzFuPHj108uRJ+6+61113nT7//HNNmjRJGzdu1MWLF/N9/sxuaZnbz3TnnXfaayiK3377TQMHDlRoaKg8PDzk6empjh07SpIOHjyY6+NatGghLy8v3XfffVqyZIl+++23Aj1fxYoVNXjwYH300UeKi4uTdGks0zvvvKNbbrlFVatWlSRde+219te3YsUK/fnnn4V6XWvXrpWnp6c8PT1Vr149rVixQg8++GC2s0h9+vSRp6en/X5h9uOGDRvUpUsXhwkHPDw8CnQW6PPPP5ePj0+RuzOuWbNGnTt3VlhYmEONmd3KNm3aZK8xMDAw23iagQMHFvi5RowYodTUVL3zzjv2ZYsWLVJERIS6dOliX/bhhx+qffv2CggIUMWKFeXp6am33347z89RYWzZskV///23hg4d6vCaMzIydPPNN2vHjh32LmbXXXedFi9erGeeeUbbtm3LsUtmTk6cOCGbzaaQkJBs65588kkdO3ZMCxcu1P3336+AgADNmzdPLVu2zDZT34gRIxQbG6vVq1dLuvQ5evfdd3XDDTcoMjIy27bnzp0rT09PeXl5qVGjRvr888+1bNkytWzZslDvUUBAgPr166eFCxcqLS1NS5cu1T333JNjd+DMY0rWmRivu+46NW3a1H7mb+vWrUpKSsp27GnXrp0iIiIclq1Zs0ZXXnmlWrRo4bCPunXrlmNXzpxUr15dkgr9Nw/AOkIVgBK3dOlS7dixQ998843uv/9+HTx4UAMGDLCvzxz7MH78ePuX+czb6NGjJcnenea1117TY489plWrVqlz586qUqWKbr311jynaM/sbhQaGuqwvGLFivYgUlgJCQm64YYb9MMPP+iZZ57Rxo0btWPHDn300UeSlGfYa9Cggb7++mtVr15dDzzwgBo0aKAGDRro1Vdfzfd5hw8frqSkJH3wwQeSpC+++EInT560d/2TpA4dOmjVqlVKS0vTkCFDVLt2bV155ZUFnmb6+uuv144dO7Rz504dOHBA586d02uvvSYvLy+HdlnHyBRmP545cybb/pCy76OcnD59WmFhYQ7jdgrjr7/+0qeffpqtxiuuuCJbjZeHvsLUmOmGG25Qo0aNtGjRIknSvn37tGvXLocv6x999JHuvPNO1apVS++++662bt2qHTt22Pd1ccjcN3379s32up977jkZY/T3339LujRWcOjQoXrrrbfUtm1bValSRUOGDMl3LNnFixfl6emZa/e8GjVq6J577tG8efO0b98+bdq0SV5eXnr44Ycd2vXt21fBwcH292zt2rX666+/cu2Gd+edd2rHjh3asmWL5s+fr8DAwCJftmHEiBHatWuXZsyYodOnT+c6fX1e48TCwsLs63M79uS07K+//tK+ffuy7Z/AwEAZYxy6FObGx8dHUt7HHwAlo+g/0QJAATVt2tQ+OUXnzp2Vnp6ut956S//973/Vt29f+y/bjz/+uMOsYZdr3LixJMnf319PPfWUnnrqKf3111/2s1a9e/fO9ZpAmcEpJiZGtWrVsi9PS0vLNr4j80tJcnKyvL297cuzfqH55ptvdOLECW3cuNF+dkpSntfYudwNN9ygG264Qenp6dq5c6fmzJmjsWPHqkaNGrrrrrtyfVyzZs103XXXadGiRbr//vu1aNEihYWFqWvXrg7tbrnlFt1yyy1KTk7Wtm3bNGvWLA0cOFB169a1j3HJTXBwsH1/5SXrL/iF2Y9Vq1bN8Ut6QSaBqFatmr777jtlZGQUKViFhISoefPmmjFjRo7rw8LC7DXmNJlJQSeqyDR8+HBNmjRJ27dv1/vvv68KFSo4fFl/9913Va9ePS1fvtzhPS3IbIqXf14vl/Xzmrlv5syZk+vMmJkBMiQkRLNnz9bs2bN17NgxrV692j5j57p163KtJSQkRCkpKbpw4YL8/f3zrb1Dhw7q2rWrVq1apVOnTtnPsvj6+mrAgAFasGCBTp48qYULFyowMFD9+vXLcTvVqlWzf17btm2rpk2bqmPHjho3bpzWrFmTbx2Xa9++vRo3bqzp06frX//6l8LDw3Nsl3lMOXnypGrXru2w7sSJE/b3+/JjT1YxMTGqW7eu/X5ISIh8fX1znf0wpzOAWWUG44K0BVC8OFMFoNQ9//zzqly5sqZMmaKMjAw1btxYkZGR2rt3r1q1apXjLTAwMNt2atSooWHDhmnAgAH65Zdfcp05L3PWt/fee89h+YoVK7JN3pD5JSfzgqSZPv30U4f7mV9+Lw9eUuGmcZYudXlr3bq13njjDUkq0MU777nnHv3www/67rvv9Omnn+Y5eN/b21sdO3bUc889J0navXt3oeorjMLsx86dO2v9+vUOM7Slp6dr+fLl+T5P9+7dlZSUlOfFd6VLrz2nX+x79eql/fv3q0GDBjnWmBmqOnfurPPnz9u7oWUqzPWPJGno0KGqWLGi5s+fr/fee09dunRx6Ppls9nk5eXlEKhiYmIKNPtfbp/XrDW3b99elSpV0oEDB3LdN1nPREpSnTp1NGbMGP3rX//K97PZpEkTSdKRI0cclv/11185zliZnp6uQ4cOyc/PT5UqVXJYN2LECKWnp+uFF17Q2rVrddddd8nPzy/P5890ww03aMiQIfrss8+KdL26J554Qr1799ajjz6aa5sbb7xR0qVAfLkdO3bo4MGD9q6dbdq0kY+PT7Zjz5YtW+yzaWbq1auXjhw5oqpVq+a4fy4PYLn57bffVKFCBfuPFwBKD2eqAJS6ypUr6/HHH9fEiRP1/vvva/DgwZo/f766d++ubt26adiwYapVq5b+/vtvHTx4ULt27dKHH34o6dLU4b169VLz5s1VuXJlHTx4UO+8847atm2b65eupk2bavDgwZo9e7Y8PT110003af/+/XrxxRezXdSzR48eqlKlikaMGKHp06erYsWKWrx4sY4fP+7Qrl27dqpcubJGjRqlqVOnytPTU++995727t2b7+ufN2+evvnmG/Xs2VN16tRRUlKS/dfpm266Kd/HDxgwQI888ogGDBig5OTkbF2UpkyZoj/++ENdunRR7dq1de7cOb366qsOY75KSkH34xNPPKHVq1frxhtv1JQpU+Tn56c33nijQFNHDxgwQIsWLdKoUaP0yy+/qHPnzsrIyNAPP/ygpk2b2s/0XXXVVdq4caM+/fRT1axZU4GBgfazEF999ZXatWunhx56SI0bN1ZSUpJ+//13rV27VvPmzVPt2rU1ZMgQvfLKKxoyZIhmzJihyMhIrV27Vl988UWh3pPQ0FD16NFDixYtkjEmWze2Xr166aOPPtLo0aPVt29fHT9+XE8//bRq1qyZbxe2a6+9Vo0bN9b48eOVlpamypUr6+OPP9Z3333n0C4gIEBz5szR0KFD9ffff6tv376qXr26Tp8+rb179+r06dN68803FRcXp86dO2vgwIFq0qSJAgMDtWPHDq1bty7Xs4+ZMn+82LZtm5o3b25f/s4772j+/PkaOHCgrr32WgUHB+uPP/7QW2+9pf/973+aMmVKtkDXqlUrNW/eXLNnz87xPcvP008/reXLl+vJJ5/Mdyr4rAYPHmy/dlZuGjdurPvuu09z5sxRhQoV1L17d/3+++968sknFR4ebr8Ib+XKlTV+/Hg988wzuvfee9WvXz8dP35c06ZNy9b9b+zYsVq5cqU6dOigcePGqXnz5srIyNCxY8f05Zdf6tFHH1Xr1q3zrGvbtm1q0aKFKleuXKjXDKAYOHeeDADlWebMZFlnszLGmIsXL5o6deqYyMhIk5aWZowxZu/evebOO+801atXN56eniY0NNTceOONZt68efbHTZo0ybRq1cpUrlzZeHt7m/r165tx48bZZ74zJucZ/JKTk82jjz5qqlevbnx8fEybNm3M1q1bc5xFa/v27aZdu3bG39/f1KpVy0ydOtW89dZb2WZZ27Jli2nbtq3x8/Mz1apVM/fee6/ZtWtXtpnhstazdetWc9ttt5mIiAjj7e1tqlatajp27GhWr15d4Pd24MCBRpJp3759tnVr1qwx3bt3N7Vq1TJeXl6mevXqpkePHubbb7/Nd7sRERGmZ8+eeba5fMa0nBRkPxpzaQa0Nm3aGG9vbxMaGmomTJhg/vOf/+Q7+58xlz4/U6ZMMZGRkcbLy8tUrVrV3HjjjWbLli32Nnv27DHt27c3fn5+2WZaO336tHnooYdMvXr1jKenp6lSpYpp2bKlmTx5sklISLC3++OPP8wdd9xhAgICTGBgoLnjjjvMli1bCjz7X6ZPPvnESDJVqlQxSUlJ2dY/++yzpm7dusbb29s0bdrULFiwIMfPcU6f119//dV07drVBAUFmWrVqpkHH3zQfPbZZw6z/2XatGmT6dmzp6lSpYrx9PQ0tWrVMj179jQffvihMcaYpKQkM2rUKNO8eXMTFBRkfH19TePGjc3UqVPNhQsX8n2dN9xwg+nRo4fDsgMHDphHH33UtGrVylSrVs1UrFjRVK5c2XTs2NG88847uW7r1VdfNZJMs2bNcm0jyTzwwAM5rpswYYKRZDZt2pTr4/P7LGfKOvufMZdmTnzuuedMo0aNjKenpwkJCTGDBw82x48fd2iXkZFhZs2aZcLDw42Xl5dp3ry5+fTTT3P8XCckJJgnnnjCNG7c2Hh5eZng4GBz1VVXmXHjxjnMqpjT5+D8+fPGz8/PvPTSS3m+FgAlw2YMFzMAAADWrVy5Uv3799fRo0cdxi+i5L399tt6+OGHdfz4cc5UAU5AqAIAAMXCGKN27dqpZcuWev31151djttIS0tTs2bNNHToUE2ePNnZ5QBuiYkqAABAsbDZbFqwYIHCwsJynJwCJeP48eMaPHhwnpNrAChZnKkCAAAAAAs4UwUAAAAAFhCqAAAAAMACQhUAAAAAWMDFf7PIyMjQiRMnFBgY6HB1ewAAAADuxRij8+fPKywsTBUq5H4+ilCVxYkTJxQeHu7sMgAAAAC4iOPHj6t27dq5ridUZREYGCjp0hsXFBTk5GoAAAAAOEt8fLzCw8PtGSE3hKosMrv8BQUFEaoAAAAA5DssiIkqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAAAAALCBUAQAAAIAFFZ1dAACUZXGJKYpNSFF8UqqCfD0V4u+lYD8vZ5cFAABKEaEKAIroxLmLemzlPn17KNa+rENkiJ69o7nCKvk6sTIAAFCa6P4HAEUQl5iSLVBJ0uZDsZq0cp/iElOcVBkAAChthCoAKILYhJRsgSrT5kOxik0gVAEA4C7o/gcARRCflJrn+vP5rAfgPhh7CZR/hCoAKIIgH8881wfmsx6Ae2DsJeAe6P4HAEUQEuClDpEhOa7rEBmikAB+hQbcHWMvAfdBqAKAIgj289KzdzTPFqw6RIbouTua07UH5U5cYoqOnErQ7mNndeR0AoGgABh7CbgPuv8BQBGFVfLVnAFRik1I0fmkVAX6eCokgLESKH/owlY0jL0E3AdnqgDAgmA/LzWoHqAWdSqrQfUAAhXKHbqwFR1jLwH3QagCAAC5ogtb0TH2EnAfhCoAAJArurAVHWMvAffBmCoAAJArurBZw9hLwD0QqgAAQK4yu7BtzqELIF3YCibYjxAFlHd0/wMAALmiCxsA5I8zVQAAIE90YQOAvBGqAABAvujCBgC5o/sfAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAAAAALCBUAQAAAIAFhCoAAAAAsIBQBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgQbkKVdOmTZPNZnO4hYaGOrssAAAAAOVYRWcXUNyuuOIKff311/b7Hh4eTqwGAAAAQHlX7kJVxYoVOTsFAAAAoNSUq+5/knTo0CGFhYWpXr16uuuuu/Tbb7/l2T45OVnx8fEONwAAAAAoqHIVqlq3bq2lS5fqiy++0IIFCxQTE6N27drpzJkzuT5m1qxZCg4Ott/Cw8NLsWIAAAAAZZ3NGGOcXURJuXDhgho0aKCJEyfqkUceybFNcnKykpOT7ffj4+MVHh6uuLg4BQUFlVapAAAAAFxMfHy8goOD880G5W5M1eX8/f111VVX6dChQ7m28fb2lre3dylWBQAAAKA8KVfd/7JKTk7WwYMHVbNmTWeXAgAAAKCcKlehavz48dq0aZOio6P1ww8/qG/fvoqPj9fQoUOdXRoAAACAcqpcdf/7448/NGDAAMXGxqpatWpq06aNtm3bpoiICGeXBgAAAKCcKleh6oMPPnB2CQAAAADcTLnq/gcAAAAApY1QBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAAAAALCBUAQAAAIAFhCoAAAAAsIBQBQAAAAAWVHR2AQDgquISUxSbkKL4pFQF+XoqxN9LwX5ezi4LAAC4GEIVAOTgxLmLemzlPn17KNa+rENkiJ69o7nCKvk6sTIAAOBq6P4HAFnEJaZkC1SStPlQrCat3Ke4xBQnVQYAAFwRZ6oAIIvYhJRsgSrT5kOxik1IoRsgAJRTdP1GURCqACCL+KTUPNefz2c9AKBsous3iorufwCQRZCPZ57rA/NZDwAoe+j6DSsIVQCQRUiAlzpEhuS4rkNkiEIC6AYCAOVNQbp+A7khVAFAFsF+Xnr2jubZglWHyBA9d0dz+tYDQDlE129YwZgqAMhBWCVfzRkQpdiEFJ1PSlWgj6dCAhisDADlFV2/YQWhCgByEexHiAIAd5HZ9XtzDl0A6fqN/ND9DwDcRFxiio6cStDuY2d15HQCg64B4DJ0/YYVnKkCADfANMEAkL/y1vWba26VHkIVAJRz+U0TPGdAFP/JAsD/V166fvNjWumi+x8AlHNMEwyUHrrZ5oz3pXRxza3Sx5kqACjnmCYYKB2cGcgZ70vpK8iPaeXhbJwr4UwVAJRzTBMMlDzODOSM98U5+DGt9HGmCgDKOaYJBkoeZwZy5irviytO2FCSNfFjWukjVAFAOZc5TfCklfscghXTBAPFhzMDOcv6vvh5eWj49fUUFV5JyWkZSklLV1xiyQYrV+x+WNSaChrE+DGt9BGqAMANlLdpggFXw5mBnF3+vvh5eei1AVFa9H20Xv/msH15SQYcV5z9tKg1FSaI8WNa6SNUAYCbKC/TBAOuiDMDObv8fRl+fT0t+j5a3x8+49CmJAOOq3Q/tFpTUYIYP6aVLiaqAAAAsCjzzECHyBCH5e5+ZuDy9yUqvFK2QJWppC7v4IrdMotSU1EvjRHs56UG1QPUok5lNage4Lafw9LAmSoAcCGuOJgaQMFwZiBnme/Lr6cS8mxXEgHHFbtlFqUmVwyHJaEs/x9IqAIAF+GKg6kBFA7dbHMW7OelKvm8LyURcFyxW2ZRanLFcFjcyvr/gXT/AwAXwLVcAJR3mWEiJyUVcFyxW2ZRanLGe1eaysP/gTZjjHF2Ea4kPj5ewcHBiouLU1BQkLPLAeAmjpxKUJeXN+W6fv0jHdWgekApVgTAnZRWt6sT5y7mOiNdzRI8G5H5+lypW2Zha3LWe1caXPn/wIJmA7r/AYALKI7+8mW5LzoA5ynNbldZx535e1eUl0cFnTqfpMTU9BI7brlit8zC1lSex+yVhzFjhCoAcAFW+8uX9b7oAJzDGddxygwTHLcKzxXDYXEoD2PGGFMFAC7ASn/58tAXHYBzFHWqbqs4buFy5WHMGKEKAFyAlcHUzvpSBKDsc1a3K45buJwrTihSWHT/AwAXUdT+8uWhL7q7YfwbXIWzul1x3EJWZX3MGKEKAFxIUfrLl4e+6O7EncaREB5dn7Ou48RxCzkpy2PG6P4HAGVceeiL7i7caRzJiXMXNWbZbnV5eZNum7tFXV7apAeX7daJcxedXRou46xuVxy3UN5wnaosuE4VgLKoPF+/pDxx5WuxFKe4xBSNWbY7xzEzHSJDSmRGOVjjjOs4cdxCWcB1qgDAjZT1vujuwl3GkRRkEgI+m67FGd2uOG6hPCFUAUA5UZb7orsLdxlH4i7hEdZx3EJ5wZgqAABKibuMI3GX8AgAmcplqJo7d67q1asnHx8ftWzZUt9++62zSwIAoFxci6Ug3CU8AkCmctf9b/ny5Ro7dqzmzp2r9u3ba/78+erevbsOHDigOnXqFHxDFy5IHh7Zl3t4SD4+ju1yU6GC5OtbtLaJiVJuc4jYbJKfX9HaXrwoZWTkXoe/f9HaJiVJ6enF09bP71LdkpScLKWlFU9bX99L77MkpaRIqXl0PylMWx+ffz4rhWmbmnqpfW68vaWKFQvfNi3t0nuRGy8vydOz8G3T0y/tu9x4el5qX9i2GRmXPmvF0bZixUvvhXTpbyIxsXjaFubvnmNEzm05RtjbhnlmaE6fRjqTUFcJyakK8PZU1QAvBXtmXHrd5eAYESzpuZsb6Mnki/r+8JlLm/LwUNsmNS+FR2+PvD/vHCMu4RhRtLb//+8+LjFFsWfOK+HCRQX6eKpqTlP6u+AxoiS/R8QlpuhMQorOJ6c6vid8j7gkp7/7vP7uLmfKmeuuu86MGjXKYVmTJk3MpEmTcmyflJRk4uLi7Lfjx48bSSbu0luZ/dajh+MG/PxybicZ07GjY9uQkNzbtmrl2DYiIve2zZo5tm3WLPe2ERGObVu1yr1tSIhj244dc2/r5+fYtkeP3Ntm/Zj17Zt324SEf9oOHZp321On/mk7enTebaOj/2k7fnzebffv/6ft1Kl5t92+/Z+2zz+fd9sNG/5p+/rrebdds+aftosW5d12xYp/2q5YkXfbRYv+abtmTd5tX3/9n7YbNuTd9vnn/2m7fXvebadO/aft/v15tx0//p+20dF5tx09+p+2p07l3Xbo0H/aJiTk3bZvX+Mgr7YcIy7dOEb8c+MYYYxkYqc8bc5dSL7UlmPEPzhGXFLMx4g/zyaawW9tMx9e2SXvthwjLt1c4Bjhqt8j4iQjycTFxZm8lKvufykpKfrxxx/VtWtXh+Vdu3bVli1bcnzMrFmzFBwcbL+Fh4eXRqkAALiVqgHe5aZ7I1xbbteDc2eJyXmcgZN0IZ/1yF+5uk7ViRMnVKtWLX3//fdq166dffnMmTO1ZMkS/fLLL9kek5ycrOTLTlvGx8crPDxccSdO5DwXPaftc25L157Cty3DXXty5Kqn7YujLV17/sExovBtOUZcwjGi8G05RhSp7ZGEDHV5ZbMkySstVR4Zjm0/e/B61c+8HpybHCOO/HlWvV76Jtema8Z3UYOwSpfucIy49O///3cfHx+v4LAw97xOlS3zj+P/M8ZkW5bJ29tb3plv3uX8/R3/gHNTkDZFaXv5Aaw4215+wC3Otpf/B1Gcbb29//lwF2dbL69//sCc1dbT858DTXG2rVjxny9PxdnWw6Pgn+HCtK1QoWTa2mwl01ZyjbYcIyRJcek2xV4wik9KVZCvp0JyGjORiWPEJRwjLuEYUbS2ZeAYEX/mrP3fKRU9JTn+bcR7eOX8Xnp7XzqmJKQ4HFOkS9deiz8T53icKUPHiPh06aJX7u/b+bTLQjXHiEsy/+7zCvuXKVehKiQkRB4eHoqJiXFYfurUKdWoUcNJVQEASsKJcxezdfHpEBmiZ+9orrBKhfgyB6BcKeqU/jkdU26IDNEDnRtq+OIdSky59OW6LB5nuMxByStXY6q8vLzUsmVLffXVVw7Lv/rqK4fugACAsi23MRObD8Vq0sp9ikvMo0sMgHKtKFP653ZM+fZQrOZ8c0jDr69nX1YWjzNc5qDklatQJUmPPPKI3nrrLS1cuFAHDx7UuHHjdOzYMY0aNcrZpQEAiklsQkqug9A3H4pVbELZ+bIDoHgV5XpweR1Tvj98RlHhlRyWlbXjjLtcI8+ZylX3P0nq37+/zpw5o+nTp+vkyZO68sortXbtWkVERDi7NABAMYlPymMgt6Tz+awHUL6FVfLVnAFRik1I0fmkS9dkCgnIfcxlfseU5LTsE26UteNMYd8TFE65C1WSNHr0aI0ePdrZZQAASgjjA1CexCWmZJscgS+61gX7Ffx9zO+Y4l0xe+eusnicKcx7gsIpl6EKAFC+ZY4P2JxDdx3GB6AsYcIV15DXMaV9w6raffycwzKOM8iq3I2pAgCUf4wPQHnAhCuuI7djyg2RIXrwxkgt/C7avozjDHJSri7+Wxzi4+MVHByc7wW+AADOl9ltivEBKIuOnEpQl5c35bp+/SMd1SDzIrUoFTkdUyRxnHFjBc0GdP8DAJRZjA9AWcaEK64nt2MKxxnkh+5/AAAATsCEK0D5QagCAABwAi7IWrziElN05FSCdh87qyOnExiThlJF9z8AAAAnyJwcYdLKfQ6zzjERQuExiyKcjYkqsmCiCgAAUJqYcMWauMQUjVm2O9ssitKlYDVnQBTvJ4qMiSoAAADKACZcsSY2ISXHQCVdmp4+NiGF9xcljjFVAAAAKLOYRRGugDNVAAAAKLOYRdF1ZHZljU9KVZCvp0L83ecsLKEKAAAAZVbmLIqbcxlTxSyKpcPdJwuh+x8AAChzmD4bmTJnUcw6PT2zKJaeuMSUbIFKujSmbdLKfW7x98mZKgAAUKa4+y/iyC6skq/mDIhiFkUnYbIQzlQBAIAyhF/EkZtgPy81qB6gFnUqq0H1gHL/Jd6VMFkIoQoAAJQhBflFHEDpYrIQQhUAAChD+EUccD2Zk4XkxF0mCyFUAQCAMoNfxAHXw2QhTFQBAADKEKbPBlyTu08WQqgCAABlRuYv4pNW7nMIVu7wi7g7X1gVZUOwn/t+JglVAACg2JVkAHDHX8SZRh5wbYQqAABQrEojALjTL+L5TSM/Z0CU27wXgKtiogoAAFBsuI5U8WMaecD1EaoAAECxIQAUP6aRB1wfoQoAABQbAkDxYxp5wPURqgAAQLEhABQ/LqwKuD5CFQAAKDYEgOLHhVUB12czxhhnF+FK4uPjFRwcrLi4OAUFBTm7HAAAypwT5y7meh2pmkz/XWSZ09S7yzTygCsoaDZgSnUAAFCs3PE6UqWhLE4jzwWL4S4IVQAAoNiVxQCA4sUFi+FOGFMFAACAYsX1yuBuCFUAAAAoVlyvDO6GUAUAAIBixfXK4G4IVQAAAChWXK8M7oZQBQAAgGJVUtcri0tM0ZFTCdp97KyOnE5gbBZcBrP/AQAAoFhlXrA4t+uVFWVmSGYThCvj4r9ZcPFfAACA4lFcFyyOS0zRmGW7c5z8okNkiOYMiGIKf5QILv4LAAAApyqu65UVZDZBQhWciTFVAAAAcGnMJghXx5kqAG4ps0tKfFKqgnw9FeJfPL+mAgCKX1mfTZD/c8o/QhUAt8NgZwAoWzJnE9ycy5iqos4mWBr4P8c90P0PgFuJS0zJ9p+bdKlP/qSV+5ieFwBcUOZsglmnabcym2Bp4P8c98GZKgBuhcHOAFA2hVXy1ZwBUcUym2Bp4f8c90GoAuBWGOwMlG+MXSnfims2wdLC/znug1AFwK2U9cHOAHLH2BW4Gv7PcR+MqQLgVjIHO+fE1Qc7A8gdY1fgivg/x30QqgC4lbI62BlA3goydgUobfyf4z7o/gfA7ZTFwc4A8sbYFbgq/s9xD4QqAG6prA12BpA3xq7AlfF/TvlH9z8AAFDmMXYFKBlxiSk6cipBu4+d1ZHTCYxPzAVnqgAAQJmXOXZl0sp92pxl9j/GrgBFw4yaBWczxhhnF+FK4uPjFRwcrLi4OAUFBTm7HAAAUAiZ16li7ApgTVxiisYs253jBDAdIkM0Z0CUW/xtFTQbcKYKAACUG4xdAYpHQWbU5G/tH4ypAgAAAOCAGTULh1AFAAAAwAEzahYOoQoAAACAA2bULBxCFQAAAAAHmTNqZg1WzKiZMyaqAAAAAJBNWCVfzRkQxYyaBUCoAgAAAJAjZtQsGLr/AQAAAIAFhCoAAAAAsKBchaq6devKZrM53CZNmuTssgAAAACUY+VuTNX06dM1cuRI+/2AgAAnVgMAAIoiLjFFsQkpik9KVZCvp0L8GdcBwHWVu1AVGBio0NBQZ5cBAACK6MS5i3ps5T59eyjWvqxDZIievaO5wir5OrEyAMhZuer+J0nPPfecqlatqhYtWmjGjBlKSUnJs31ycrLi4+MdbgAAwDniElOyBSpJ2nwoVpNW7lNcYt7/r8P1xSWm6MipBO0+dlZHTiewT1EulKszVQ8//LCuueYaVa5cWdu3b9fjjz+u6OhovfXWW7k+ZtasWXrqqadKsUoAAJCb2ISUbIEq0+ZDsYpNSKEbYBnGWUiUVzZjjHF2EXmZNm1avqFnx44datWqVbblK1euVN++fRUbG6uqVavm+Njk5GQlJyfb78fHxys8PFxxcXEKCgqyVjwAACiU3cfO6ra5W3Jdv2p0O7WoU7kUK0JxiUtM0Zhlu3MMzR0iQzRnQBSBGS4nPj5ewcHB+WYDlz9TNWbMGN111115tqlbt26Oy9u0aSNJOnz4cK6hytvbW97e3pZqBAAAxSPIxzPP9YH5rIfr4iwkyjOXD1UhISEKCQkp0mN3794tSapZs2ZxlgQAAEpISICXOkSGaHMuZzNCAvjSXVbFJ6Xmuf58PusBV1ZuJqrYunWrXnnlFe3Zs0fR0dFasWKF7r//fvXp00d16tRxdnkAAKAAgv289OwdzdUh0vEH1Q6RIXrujuacySjDOAuJ8szlz1QVlLe3t5YvX66nnnpKycnJioiI0MiRIzVx4kRnlwYAAAohrJKv5gyIUmxCis4npSrQx1MhAVynqqzjLCTKM5efqKK0FXQwGgAAAArnxLmLmrRyn0OwyjwLWZPZ/+CCSnWiivT0dP3000+KiIhQ5crMyAMAKL/iElMUm5Ci+KRUBfl6KsSfMyhAQXEWEuVVkULV2LFjddVVV2nEiBFKT09Xx44dtWXLFvn5+WnNmjXq1KlTMZcJAIDzcY0dwLpgP0IUyp8iTVTx3//+V1dffbUk6dNPP1V0dLR+/vlnjR07VpMnTy7WAgEAcAVxiSnZApV0aSroSSv3KS4xxUmVAQCcrUihKjY2VqGhoZKktWvXql+/fmrUqJFGjBihn376qVgLBADAFRTkGjsAAPdUpFBVo0YNHThwQOnp6Vq3bp1uuukmSVJiYqI8PDyKtUAAcDdxiSk6cipBu4+d1ZHTCZwBcRFcYwcAkJsijam65557dOedd6pmzZqy2Wz617/+JUn64Ycf1KRJk2ItEADcCWN2XBfX2AEA5KZIoWratGm68sordfz4cfXr10/e3t6SJA8PD02aNKlYCwQAd5HfmJ05A6JcYnC3u85+xzV2AAC54TpVWXCdKgDOcuRUgrq8vCnX9esf6agG1QNKsaLs3P1MGtfYAQD3UuzXqXrttdcK/OQPPfRQgdsCAC5x9TE7ZeVMWkniGjsAgJwUOFS98sorBWpns9kIVQBQBK4+Zqcgs9+5Q7jgGjsAgKwKHKqio6NLsg4AcHuuPmbH1c+kAQDgLEWaUh0AUPyC/bz07B3N1SEyxGF55pgdZ58dcfUzaQAAOEuRZv+TpD/++EOrV6/WsWPHlJLieA2Vl19+2XJhAOCOXHnMjqufSQMAwFmKFKrWr1+vPn36qF69evrll1905ZVX6vfff5cxRtdcc01x1wgAbsVVx+xknknLbfY7V6wZAIDSUKQp1a+77jrdfPPNmj59ugIDA7V3715Vr15dgwYN0s0336x///vfJVFrqWBKdQDIW+Z1qlztTBoAAMWt2KdUv9zBgwe1bNmySxuoWFEXL15UQECApk+frltuuaVMhypc4q4X9wSQP1c9kwYAgLMUKVT5+/srOTlZkhQWFqYjR47oiiuukCTFxuY83S7KDne/uCcAAABQGEWa/a9Nmzb6/vvvJUk9e/bUo48+qhkzZmj48OFq06ZNsRaI0pXfxT3jElNyeSQAAADgnop0purll19WQkKCJGnatGlKSEjQ8uXL1bBhwwJfJBiuiYt7AgAAAIVTpFBVv359+7/9/Pw0d+7cYisIzsXFPQEAAIDC4eK/cMDFPQEAAIDCKVKoqlChgjw8PHK9oezKvLhnTri4JwAAAJBdkbr/ffzxxw73U1NTtXv3bi1ZskRPPfVUsRQG5+DingAAAEDhFOniv7l5//33tXz5cn3yySfFtclSx8V/L+HingAAAHB3JXrx39y0bt1aI0eOLM5Nwkm4uCcAAABQMMU2UcXFixc1Z84c1a5du7g2CQAAAAAur0hnqipXriybzWa/b4zR+fPn5efnp3fffbfYigMAAAAAV1ekUPXKK684hKoKFSqoWrVqat26tSpXrlxsxQEAAACAqytSqBo2bFgxlwEAAAAAZVOBQ9W+ffsKvNHmzZsXqRgAAAAAKGsKHKpatGghm82mzBnYL+/+l1V6err1ygAAAACgDCjw7H/R0dH67bffFB0drY8++kj16tXT3LlztXv3bu3evVtz585VgwYNtHLlypKsFwAAAABcSoHPVEVERNj/3a9fP7322mvq0aOHfVnz5s0VHh6uJ598UrfeemuxFgkAAAAArqpI16n66aefVK9evWzL69WrpwMHDlguCgAAAADKiiKFqqZNm+qZZ55RUlKSfVlycrKeeeYZNW3atNiKAwAAAABXV6Qp1efNm6fevXsrPDxcV199tSRp7969stlsWrNmTbEWCAAAAACuzGYyp/MrpMTERL377rv6+eefZYxRs2bNNHDgQPn7+xd3jaUqPj5ewcHBiouLU1BQkLPLAQAAAOAkBc0GRTpTJUl+fn667777ivpwAAAAACgXChyqVq9ere7du8vT01OrV6/Os22fPn0sFwYAAAAAZUGBu/9VqFBBMTExql69uipUyH1+C5vNVqYv/kv3PwAAAABSCXT/y8jIyPHfAAAAAODOijSlek7OnTtXXJsCAAAAgDKjSKHqueee0/Lly+33+/XrpypVqqhWrVrau3dvsRUHAAAAAK6uSKFq/vz5Cg8PlyR99dVX+vrrr7Vu3Tp1795dEyZMKNYCAQAAAMCVFWlK9ZMnT9pD1Zo1a3TnnXeqa9euqlu3rlq3bl2sBQIAAACAKyvSmarKlSvr+PHjkqR169bppptukiQZY8r0zH8AAAAAUFhFOlN1++23a+DAgYqMjNSZM2fUvXt3SdKePXvUsGHDYi0QAAAAAFxZkULVK6+8orp16+r48eN6/vnnFRAQIOlSt8DRo0cXa4EAAAAA4MoKfPFfd8HFfwEAAABIBc8GRb5O1TvvvKPrr79eYWFhOnr0qCRp9uzZ+uSTT4q6SQAAAAAoc4oUqt5880098sgj6t69u86dO2efnKJSpUqaPXt2cdYHAAAAAC6tSKFqzpw5WrBggSZPniwPDw/78latWumnn34qtuIAAAAAwNUVKVRFR0crKioq23Jvb29duHDBclEAAAAAUFYUKVTVq1dPe/bsybb8888/V9OmTa3WBAAAAABlRpGmVJ8wYYIeeOABJSUlyRij7du3a9myZZo5c6befvvt4q4RAAAAAFxWkULVPffco7S0NE2cOFGJiYkaOHCgatWqpTlz5uiGG24o7hoBAAAAwGUVeUr1kSNH6ujRozp16pRiYmK0fft27d69Ww0bNizO+gAAAADApRUqVJ07d06DBg1StWrVFBYWptdee01VqlTRG2+8oYYNG2rbtm1auHBhSdUKAAAAAC6nUN3//u///k+bN2/W0KFDtW7dOo0bN07r1q1TUlKS1q5dq44dO5ZUnQAAAADgkgoVqj777DMtWrRIN910k0aPHq2GDRuqUaNGXPAXAAAAgNsqVPe/EydOqFmzZpKk+vXry8fHR/fee2+JFAYAAAAAZUGhQlVGRoY8PT3t9z08POTv71/sReVkxowZateunfz8/FSpUqUc2xw7dky9e/eWv7+/QkJC9NBDDyklJaVU6gMAAADgngrV/c8Yo2HDhsnb21uSlJSUpFGjRmULVh999FHxVfj/paSkqF+/fmrbtm2O18JKT09Xz549Va1aNX333Xc6c+aMhg4dKmOM5syZU+z1AAAAAIBUyFA1dOhQh/uDBw8u1mLy8tRTT0mSFi9enOP6L7/8UgcOHNDx48cVFhYmSXrppZc0bNgwzZgxQ0FBQaVVKgAAAAA3UqhQtWjRopKqw7KtW7fqyiuvtAcqSerWrZuSk5P1448/qnPnzjk+Ljk5WcnJyfb78fHxJV4rAAAAgPKjyBf/dTUxMTGqUaOGw7LKlSvLy8tLMTExuT5u1qxZCg4Ott/Cw8NLulQAAAAA5YhTQ9W0adNks9nyvO3cubPA27PZbNmWGWNyXJ7p8ccfV1xcnP12/PjxIr0WAAAAAO6pUN3/ituYMWN011135dmmbt26BdpWaGiofvjhB4dlZ8+eVWpqarYzWJfz9va2T7zhSuISUxSbkKL4pFQF+XoqxN9LwX5ezi4LAAAAQBZODVUhISEKCQkplm21bdtWM2bM0MmTJ1WzZk1Jlyav8Pb2VsuWLYvlOUrLiXMX9djKffr2UKx9WYfIED17R3OFVfJ1YmUAAAAAsiozY6qOHTumPXv26NixY0pPT9eePXu0Z88eJSQkSJK6du2qZs2a6e6779bu3bu1fv16jR8/XiNHjixTM//FJaZkC1SStPlQrCat3Ke4RK67BQAAALgSp56pKowpU6ZoyZIl9vtRUVGSpA0bNqhTp07y8PDQZ599ptGjR6t9+/by9fXVwIED9eKLLzqr5CKJTUjJFqgybT4Uq9iEFLoBAgAAAC6kzISqxYsX53qNqkx16tTRmjVrSqegEhKflJrn+vP5rAcAAABQuspM9z93EeTjmef6wHzWAwAAAChdhCoXExLgpQ6ROU/e0SEyRCEBdP0DAAAAXAmhysUE+3np2TuaZwtWHSJD9NwdzRlPBQAAALiYMjOmyp2EVfLVnAFRik1I0fmkVAX6eCokgOtUAQAAAK6IUOWigv0IUQAAAEBZQPc/AAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAAAAALCBUAQAAAIAFhCoAAAAAsIBQBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAAAAALCBUAQAAAIAFhCoAAAAAsIBQBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwoMyEqhkzZqhdu3by8/NTpUqVcmxjs9my3ebNm1e6hQIAAABwKxWdXUBBpaSkqF+/fmrbtq3efvvtXNstWrRIN998s/1+cHBwaZQHAAAAwE2VmVD11FNPSZIWL16cZ7tKlSopNDS0wNtNTk5WcnKy/X58fHyR6gMAAADgnspM97+CGjNmjEJCQnTttddq3rx5ysjIyLP9rFmzFBwcbL+Fh4eXUqUAAAAAyoNyFaqefvppffjhh/r6669111136dFHH9XMmTPzfMzjjz+uuLg4++348eOlVC0AAACA8sCp3f+mTZtm79aXmx07dqhVq1YF2t4TTzxh/3eLFi0kSdOnT3dYnpW3t7e8vb0LtH0AAAAAyMqpoWrMmDG666678mxTt27dIm+/TZs2io+P119//aUaNWoUeTsAAAAAkBunhqqQkBCFhISU2PZ3794tHx+fXKdgBwAAAACryszsf8eOHdPff/+tY8eOKT09XXv27JEkNWzYUAEBAfr0008VExOjtm3bytfXVxs2bNDkyZN133330b0PAAAAQIkpM6FqypQpWrJkif1+VFSUJGnDhg3q1KmTPD09NXfuXD3yyCPKyMhQ/fr1NX36dD3wwAPOKhkAAACAG7AZY4yzi3Al8fHxCg4OVlxcnIKCgpxdDgAAAAAnKWg2KFdTqgMAAABAaSNUAQAAAIAFhCoAAAAAsIBQBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAAAAALCBUAQAAAIAFhCoAAAAAsIBQBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAAAAALCBUAQAAAIAFhCoAAAAAsIBQBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMCCMhGqfv/9d40YMUL16tWTr6+vGjRooKlTpyolJcWh3bFjx9S7d2/5+/srJCREDz30ULY2AAAAAFCcKjq7gIL4+eeflZGRofnz56thw4bav3+/Ro4cqQsXLujFF1+UJKWnp6tnz56qVq2avvvuO505c0ZDhw6VMUZz5sxx8isAAAAAUF7ZjDHG2UUUxQsvvKA333xTv/32myTp888/V69evXT8+HGFhYVJkj744AMNGzZMp06dUlBQUIG2Gx8fr+DgYMXFxRX4MQAAAADKn4JmgzLR/S8ncXFxqlKliv3+1q1bdeWVV9oDlSR169ZNycnJ+vHHH3PdTnJysuLj4x1uAAAAAFBQZTJUHTlyRHPmzNGoUaPsy2JiYlSjRg2HdpUrV5aXl5diYmJy3dasWbMUHBxsv4WHh5dY3QAAAADKH6eGqmnTpslms+V527lzp8NjTpw4oZtvvln9+vXTvffe67DOZrNlew5jTI7LMz3++OOKi4uz344fP148Lw4AAACAW3DqRBVjxozRXXfdlWebunXr2v994sQJde7cWW3bttV//vMfh3ahoaH64YcfHJadPXtWqamp2c5gXc7b21ve3t6FLx4AAAAA5ORQFRISopCQkAK1/fPPP9W5c2e1bNlSixYtUoUKjifZ2rZtqxkzZujkyZOqWbOmJOnLL7+Ut7e3WrZsWey1AwAAAIBURmb/O3HihDp27Kg6depo6dKl8vDwsK8LDQ2VdGlK9RYtWqhGjRp64YUX9Pfff2vYsGG69dZbCzWlOrP/AQAAAJAKng3KxHWqvvzySx0+fFiHDx9W7dq1HdZlZkIPDw999tlnGj16tNq3by9fX18NHDjQfh0rAAAAACgJZeJMVWniTBUAAAAAyQ2uUwUAAAAAroBQBQAAAAAWEKoAAAAAwAJCFQAAAABYQKgCAAAAAAsIVQAAAABgAaEKAAAAACwgVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAgorOLgAAyqO4xBTFJqQoPilVQb6eCvH3UrCfl7PLAgAAJYBQBQDF7MS5i3ps5T59eyjWvqxDZIievaO5wir5OrEyAABQEuj+BwDFKC4xJVugkqTNh2I1aeU+xSWmOKkyAABQUghVAFCMYhNSsgWqTJsPxSo2gVAFAEB5Q6gCgGIUn5Sa5/rz+awHAABlD6EKAIpRkI9nnusD81kPAADKHkIVABSjkAAvdYgMyXFdh8gQhQQwAyAAAOUNoQoAilGwn5eevaN5tmDVITJEz93RnGnVAQAoh5hSHQCKWVglX80ZEKXYhBSdT0pVoI+nQgK4ThUAAOUVoQoASkCwHyEKAAB3Qfc/AAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGBBRWcX4GqMMZKk+Ph4J1cCAAAAwJkyM0FmRsgNoSqL8+fPS5LCw8OdXAkAAAAAV3D+/HkFBwfnut5m8otdbiYjI0MnTpxQYGCgbDabs8txEB8fr/DwcB0/flxBQUHOLge5YD+VDeynsoN9VTawn8oG9lPZwH5yHcYYnT9/XmFhYapQIfeRU5ypyqJChQqqXbu2s8vIU1BQEH9gZQD7qWxgP5Ud7Kuygf1UNrCfygb2k2vI6wxVJiaqAAAAAAALCFUAAAAAYAGhqgzx9vbW1KlT5e3t7exSkAf2U9nAfio72FdlA/upbGA/lQ3sp7KHiSoAAAAAwALOVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQpWLSUtL0xNPPKF69erJ19dX9evX1/Tp05WRkZFj+/vvv182m02zZ88u3ULdXEH308GDB9WnTx8FBwcrMDBQbdq00bFjx5xUtXsqyL5KSEjQmDFjVLt2bfn6+qpp06Z68803nVi1ezp//rzGjh2riIgI+fr6ql27dtqxY4d9vTFG06ZNU1hYmHx9fdWpUyf973//c2LF7imv/ZSamqrHHntMV111lfz9/RUWFqYhQ4boxIkTTq7a/eT393Q5vks4T0H2E98lyggDl/LMM8+YqlWrmjVr1pjo6Gjz4YcfmoCAADN79uxsbT/++GNz9dVXm7CwMPPKK6+UfrFurCD76fDhw6ZKlSpmwoQJZteuXebIkSNmzZo15q+//nJi5e6nIPvq3nvvNQ0aNDAbNmww0dHRZv78+cbDw8OsWrXKiZW7nzvvvNM0a9bMbNq0yRw6dMhMnTrVBAUFmT/++MMYY8yzzz5rAgMDzcqVK81PP/1k+vfvb2rWrGni4+OdXLl7yWs/nTt3ztx0001m+fLl5ueffzZbt241rVu3Ni1btnR22W4nv7+nTHyXcK789hPfJcoOQpWL6dmzpxk+fLjDsttvv90MHjzYYdkff/xhatWqZfbv328iIiI4EJayguyn/v37Z9tvKH0F2VdXXHGFmT59ukOba665xjzxxBOlUiOMSUxMNB4eHmbNmjUOy6+++mozefJkk5GRYUJDQ82zzz5rX5eUlGSCg4PNvHnzSrtct5XffsrJ9u3bjSRz9OjR0igRpuD7ie8SzlWQ/cR3ibKD7n8u5vrrr9f69ev166+/SpL27t2r7777Tj169LC3ycjI0N13360JEyboiiuucFapbi2//ZSRkaHPPvtMjRo1Urdu3VS9enW1bt1aq1atcmLV7qkgf1PXX3+9Vq9erT///FPGGG3YsEG//vqrunXr5qyy3U5aWprS09Pl4+PjsNzX11ffffedoqOjFRMTo65du9rXeXt7q2PHjtqyZUtpl+u28ttPOYmLi5PNZlOlSpVKoUJIBdtPfJdwvvz2E98lyhhnpzo4ysjIMJMmTTI2m81UrFjR2Gw2M3PmTIc2M2fONP/6179MRkaGMcbw65IT5LefTp48aSQZPz8/8/LLL5vdu3ebWbNmGZvNZjZu3OjEyt1PQf6mkpOTzZAhQ4wkU7FiRePl5WWWLl3qpIrdV9u2bU3Hjh3Nn3/+adLS0sw777xjbDabadSokfn++++NJPPnn386PGbkyJGma9euTqrYPeW1n7K6ePGiadmypRk0aJATKnVv+e0nvku4hrz2E98lyhZClYtZtmyZqV27tlm2bJnZt2+fWbp0qalSpYpZvHixMcaYnTt3mho1ajh8seBAWPry209//vmnkWQGDBjg8LjevXubu+66yxklu6389pUxxrzwwgumUaNGZvXq1Wbv3r1mzpw5JiAgwHz11VdOrNz9HD582HTo0MFIMh4eHubaa681gwYNMk2bNrWHqhMnTjg85t577zXdunVzUsXuKa/9dLmUlBRzyy23mKioKBMXF+ekat1XXvuJ7xKuI6/9xHeJsoVQ5WJq165tXn/9dYdlTz/9tGncuLExxphXXnnF2Gw24+HhYb9JMhUqVDARERFOqNg95befkpOTTcWKFc3TTz/t0GbixImmXbt2pVYn8t9XiYmJxtPTM1uf9hEjRvBl3UkSEhLs4enOO+80PXr0MEeOHDGSzK5duxza9unTxwwZMsQZZbq9nPZTppSUFHPrrbea5s2bm9jYWGeVCJPzfuK7hOvJaT/xXaJsYUyVi0lMTFSFCo67xcPDwz7989133619+/Zpz5499ltYWJgmTJigL774whklu6X89pOXl5euvfZa/fLLLw5tfv31V0VERJRanch/X6Wmpio1NTXPNihd/v7+qlmzps6ePasvvvhCt9xyi+rVq6fQ0FB99dVX9nYpKSnatGmT2rVr58Rq3VdO+0m69Dd155136tChQ/r6669VtWpVJ1fq3nLaT3yXcD057Se+S5QtFZ1dABz17t1bM2bMUJ06dXTFFVdo9+7devnllzV8+HBJUtWqVbP9B+Xp6anQ0FA1btzYGSW7pfz2kyRNmDBB/fv3V4cOHdS5c2etW7dOn376qTZu3Oi8wt1QfvsqKChIHTt21IQJE+Tr66uIiAht2rRJS5cu1csvv+zk6t3LF198IWOMGjdurMOHD2vChAlq3Lix7rnnHtlsNo0dO1YzZ85UZGSkIiMjNXPmTPn5+WngwIHOLt2t5LWf0tLS1LdvX+3atUtr1qxRenq6YmJiJElVqlSRl5eXk6t3H3ntJ09PT75LuIi89pPEd4kyxbknypBVfHy8efjhh02dOnWMj4+PqV+/vpk8ebJJTk7O9TH0gy59Bd1Pb7/9tmnYsKHx8fExV199Ndc9coKC7KuTJ0+aYcOGmbCwMOPj42MaN25sXnrpJfsAbpSO5cuXm/r16xsvLy8TGhpqHnjgAXPu3Dn7+oyMDDN16lQTGhpqvL29TYcOHcxPP/3kxIrdU177KTo62kjK8bZhwwbnFu5m8vt7yorvEs5RkP3Ed4mywWaMMc4MdQAAAABQljGmCgAAAAAsIFQBAAAAgAWEKgAAAACwgFAFAAAAABYQqgAAAADAAkIVAAAAAFhAqAIAAAAACwhVAAAAAGABoQoAyrlp06apRYsW9vvDhg3TrbfeWup1/P7777LZbNqzZ0+pP3d+OnXqpLFjx5bKc9lsNq1atapUnsvVfPPNN2rSpIkyMjKKvI01a9YoKirK0jYAoLgRqgDACYYNGyabzSabzSZPT0/Vr19f48eP14ULF0r8uV999VUtXry4QG2dEYQOHz6s4cOHq06dOvL29latWrXUpUsXvffee0pLSyu1OqzKGmYznTx5Ut27dy/R5168eLH982Wz2VSjRg317t1b//vf/wq9nUqVKhVbXRMnTtTkyZNVocKlrx+7d+9WVFSUAgIC1KdPH509e9beNi0tTddcc4127NjhsI1evXrJZrPp/fffL7a6AMAqQhUAOMnNN9+skydP6rffftMzzzyjuXPnavz48Tm2TU1NLbbnDQ4OLtYvysVp+/btuuaaa3Tw4EG98cYb2r9/v9asWaPhw4dr3rx5eYaC4nyPSlJoaKi8vb1L/HmCgoJ08uRJnThxQp999pkuXLignj17KiUlpcSfOydbtmzRoUOH1K9fP/uye++9VzfeeKN27dqlc+fOaebMmfZ1L774oq6//npde+212bZ1zz33aM6cOaVSNwAUBKEKAJzE29tboaGhCg8P18CBAzVo0CB7t7DMsxwLFy5U/fr15e3tLWOM4uLidN9996l69eoKCgrSjTfeqL179zps99lnn1WNGjUUGBioESNGKCkpyWF91u5/GRkZeu6559SwYUN5e3urTp06mjFjhiSpXr16kqSoqCjZbDZ16tTJ/rhFixapadOm8vHxUZMmTTR37lyH59m+fbuioqLk4+OjVq1aaffu3Xm+H8YYDRs2TI0aNdL333+v3r17KzIyUlFRURo0aJC+/fZbNW/eXNI/Z9BWrFihTp06ycfHR++++67OnDmjAQMGqHbt2vLz89NVV12lZcuWOTzPhQsXNGTIEAUEBKhmzZp66aWXstWSUxe9SpUqOZzhe+yxx9SoUSP5+fmpfv36evLJJ+3BbvHixXrqqae0d+9e+9mizMdm3fZPP/2kG2+8Ub6+vqpataruu+8+JSQk2Ndn7q8XX3xRNWvWVNWqVfXAAw/kGyJtNptCQ0NVs2ZNtWrVSuPGjdPRo0f1yy+/2Nu8/PLLuuqqq+Tv76/w8HCNHj3a/twbN27UPffco7i4OPtrmDZtmiQpJSVFEydOVK1ateTv76/WrVtr48aNedbzwQcfqGvXrvLx8bEvO3jwoEaOHKlGjRppwIABOnDggCTpt99+08KFC+2fw6z69Omj7du367fffsvzOQGgtBCqAMBF+Pr6OnxRPnz4sFasWKGVK1fau9/17NlTMTExWrt2rX788Uddc8016tKli/7++29J0ooVKzR16lTNmDFDO3fuVM2aNbOFnawef/xxPffcc3ryySd14MABvf/++6pRo4akS8FIkr7++mudPHlSH330kSRpwYIFmjx5smbMmKGDBw9q5syZevLJJ7VkyRJJl4JLr1691LhxY/3444+aNm1armfhMu3Zs0cHDx7U+PHj7d3DsrLZbA73H3vsMT300EM6ePCgunXrpqSkJLVs2VJr1qzR/v37dd999+nuu+/WDz/8YH/MhAkTtGHDBn388cf68ssvtXHjRv3444951paTwMBALV68WAcOHNCrr76qBQsW6JVXXpEk9e/fX48++qiuuOIKnTx5UidPnlT//v2zbSMxMVE333yzKleurB07dujDDz/U119/rTFjxji027Bhg44cOaINGzZoyZIlWrx4cYG7cErSuXPn7N3lPD097csrVKig1157Tfv379eSJUv0zTffaOLEiZKkdu3aafbs2fYzXidPnrTvw3vuuUfff/+9PvjgA+3bt0/9+vXTzTffrEOHDuVaw+bNm9WqVSuHZVdffbW++uorpaWlaf369fbQPGrUKD3//PMKDAzMcVsRERGqXr26vv322wK/BwBQogwAoNQNHTrU3HLLLfb7P/zwg6lataq58847jTHGTJ061Xh6eppTp07Z26xfv94EBQWZpKQkh201aNDAzJ8/3xhjTNu2bc2oUaMc1rdu3dpcffXVOT53fHy88fb2NgsWLMixzujoaCPJ7N6922F5eHi4ef/99x2WPf3006Zt27bGGGPmz59vqlSpYi5cuGBf/+abb+a4rUwffPCBkWR27dplX/bXX38Zf39/++2NN95wqGv27Nk5butyPXr0MI8++qgxxpjz588bLy8v88EHH9jXnzlzxvj6+pqHH37YvkyS+fjjjx22ExwcbBYtWpTr8zz//POmZcuW9vtTp051eN9z2vZ//vMfU7lyZZOQkGBf/9lnn5kKFSqYmJgYY8yl/RUREWHS0tLsbfr162f69++fay2LFi0ykoy/v7/x8/Mzkowk06dPn1wfY4wxK1asMFWrVnXYTnBwsEObw4cPG5vNZv7880+H5V26dDGPP/54rtsODg42S5cudVi2f/9+06FDB1OnTh0zYMAAExcXZ5YsWWJuueUW88cff5iuXbuaBg0amMmTJ2fbXlRUlJk2bVqerwcASktFp6U5AHBza9asUUBAgNLS0pSamqpbbrnFYZxIRESEqlWrZr//448/KiEhQVWrVnXYzsWLF3XkyBFJl7pTjRo1ymF927ZttWHDhhxrOHjwoJKTk9WlS5cC13369GkdP35cI0aM0MiRI+3L09LSFBwcbN/u1VdfLT8/P4c6CuLys1FVq1a1n6Xr1KlTtvFAWc98pKen69lnn9Xy5cv1559/Kjk5WcnJyfL395ckHTlyRCkpKQ61VKlSRY0bNy5QbZf773//q9mzZ+vw4cNKSEhQWlqagoKCCrWNzPcpsz5Jat++vTIyMvTLL7/YzxheccUV8vDwsLepWbOmfvrppzy3HRgYqF27diktLU2bNm3SCy+8oHnz5jm02bBhg2bOnKkDBw4oPj5eaWlpSkpK0oULFxxqutyuXbtkjFGjRo0clicnJ2f7bF7u4sWLDl3/Ml/Xpk2b7PfPnDmjadOmafPmzXrwwQfVvn17ffTRR7r22mvVunVr9e7d297W19dXiYmJeb4HAFBaCFUA4CSdO3fWm2++KU9PT4WFhTl0y5KU7UttRkaGatasmePYlaJOPOHr61vox2ROZb1gwQK1bt3aYV3mF39jTKG3GxkZKUn6+eef7bPmeXh4qGHDhpKkihWz/5eV9T166aWX9Morr2j27Nn2sUJjx461h7GC1mWz2bK1vbxr5rZt23TXXXfpqaeeUrdu3RQcHKwPPvggx/FZeTHGZOvSeHkNmbJ+Nmw2W75TileoUMH+3jVp0kQxMTHq37+/Nm/eLEk6evSoevTooVGjRunpp59WlSpV9N1332nEiBF5jtfKyMiQh4eHfvzxR4egJ0kBAQG5Pi4kJMRhdr+cjBs3TmPHjlXt2rW1ceNGPfPMM/L391fPnj21ceNGh1D1999/O/zoAADOxJgqAHASf39/NWzYUBEREdm+NOfkmmuuUUxMjCpWrKiGDRs63EJCQiRJTZs21bZt2xwel/X+5SIjI+Xr66v169fnuN7Ly0vSpTNAmWrUqKFatWrpt99+y1ZH5sQWzZo10969e3Xx4sUC1SFdmgyjSZMmevHFF4t8DaJvv/1Wt9xyiwYPHqyrr75a9evXdxjn07BhQ3l6ejrUcvbsWf36668O26lWrZpOnjxpv3/o0CGHsyLff/+9IiIiNHnyZLVq1UqRkZE6evSowza8vLwc3recNGvWTHv27HGYSv/7779XhQoVsp0JsmrcuHHau3evPv74Y0nSzp07lZaWppdeeklt2rRRo0aNdOLEiXxfQ1RUlNLT03Xq1Kls+z80NDTX54+KirJPRJGT9evX6+eff7aPJ0tPT7eHu9TUVIc6kpKSdOTIEUVFRRXuTQCAEkKoAoAy4qabblLbtm1166236osvvtDvv/+uLVu26IknntDOnTslSQ8//LAWLlyohQsX6tdff9XUqVPznIbcx8dHjz32mCZOnKilS5fqyJEj2rZtm95++21JUvXq1eXr66t169bpr7/+UlxcnKRLsxPOmjVLr776qn799Vf99NNPWrRokV5++WVJ0sCBA1WhQgWNGDFCBw4c0Nq1a/Xiiy/m+fpsNpsWLVqkX375Re3bt9fq1at16NAhHThwQPPmzdPp06eznRnJqmHDhvrqq6+0ZcsWHTx4UPfff79iYmLs6wMCAjRixAhNmDBB69ev1/79+zVs2LBsE2PceOONev3117Vr1y7t3LlTo0aNcgi+DRs21LFjx/TBBx/oyJEjeu211+xhJVPdunUVHR2tPXv2KDY2VsnJydnqHTRokHx8fDR06FDt379fGzZs0IMPPqi7777b3vWvuAQFBenee+/V1KlTZYxRgwYNlJaWpjlz5ui3337TO++8k617YN26dZWQkKD169crNjZWiYmJatSokQYNGqQhQ4boo48+UnR0tHbs2KHnnntOa9euzfX5u3Xrpu+++y7HdRcvXtQDDzyg//znP/Z90b59e73xxhvau3evVq5cqfbt29vbb9u2Td7e3gXuUgoAJc6ZA7oAwF1lnagiq9wmOYiPjzcPPvigCQsLM56eniY8PNwMGjTIHDt2zN5mxowZJiQkxAQEBJihQ4eaiRMn5jpRhTHGpKenm2eeecZEREQYT09PU6dOHTNz5kz7+gULFpjw8HBToUIF07FjR/vy9957z7Ro0cJ4eXmZypUrmw4dOpiPPvrIvn7r1q3m6quvNl5eXqZFixZm5cqVeU5UkemXX34xQ4cONbVr1zYVK1Y0wcHBpkOHDmb+/PkmNTXVGJP7BBpnzpwxt9xyiwkICDDVq1c3TzzxhBkyZIjD6z1//rwZPHiw8fPzMzVq1DDPP/+86dixo8NEFX/++afp2rWr8ff3N5GRkWbt2rXZJqqYMGGCqVq1qgkICDD9+/c3r7zyisOkDklJSeaOO+4wlSpVMpLsj1WWSTD27dtnOnfubHx8fEyVKlXMyJEjzfnz53PdX8YY8/DDDzvsi6xymmDCGGOOHj1qKlasaJYvX26MMebll182NWvWNL6+vqZbt25m6dKlRpI5e/as/TGjRo0yVatWNZLM1KlTjTHGpKSkmClTppi6desaT09PExoaam677Tazb9++XGv6+++/ja+vr/n555+zrZs0aZJ9MpFMhw4dMtdee60JCgoyo0aNMunp6fZ19913n7n//vtzfS4AKG02Y4rQ8R0AAKCQJk6cqLi4OM2fP7/I2zh9+rSaNGminTt32rubAoCz0f0PAACUismTJysiIiLfsWZ5iY6O1ty5cwlUAFwKZ6oAAAAAwALOVAEAAACABYQqAAAAALCAUAUAAAAAFhCqAAAAAMACQhUAAAAAWECoAgAAAAALCFUAAAAAYAGhCgAAAAAsIFQBAAAAgAX/DzczDp/HNv6+AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#Residuals plot for the SVR model\n",
+    "residuals_svr = y_test - y_pred_test_svr\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "sns.scatterplot(x=y_pred_test_svr, y=residuals_svr)\n",
+    "plt.axhline(0, color='red', linestyle='--')\n",
+    "plt.title(\"Residuals vs Predicted Values (SVR Model)\")\n",
+    "plt.xlabel(\"Predicted Graduation Rate (%)\")\n",
+    "plt.ylabel(\"Residuals\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 416,
+   "id": "ab0c6214",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install catboost"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 417,
+   "id": "274e41e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CatBoost Cross-validation MSE scores: [19.67740813 23.08447171 15.93325955 16.35640524 16.2305397 ]\n",
+      "Mean MSE (CatBoost): 18.256416865688717\n",
+      "Standard Deviation of MSE (CatBoost): 2.772746366838874\n"
+     ]
+    }
+   ],
+   "source": [
+    "#check metrics for CatBoost model cross-validation\n",
+    "from catboost import CatBoostRegressor\n",
+    "catboost_model = CatBoostRegressor(iterations=1000, learning_rate=0.1, depth=6, random_seed=42, verbose=0)\n",
+    "catboost_cv_scores = cross_val_score(catboost_model, X_train_scaled, y_train, cv=5, scoring='neg_mean_squared_error')\n",
+    "\n",
+    "# Convert negative MSE scores to positive\n",
+    "catboost_cv_scores = -catboost_cv_scores\n",
+    "\n",
+    "print(\"CatBoost Cross-validation MSE scores:\", catboost_cv_scores)\n",
+    "print(\"Mean MSE (CatBoost):\", np.mean(catboost_cv_scores))\n",
+    "print(\"Standard Deviation of MSE (CatBoost):\", np.std(catboost_cv_scores))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 418,
+   "id": "915e5621",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train MSE (CatBoost): 2.8250906342440056e-06\n",
+      "Train R2 (CatBoost): 0.9999999423089759\n"
+     ]
+    }
+   ],
+   "source": [
+    "#check the metrics for catboost model for training set\n",
+    "catboost_model.fit(X_train_scaled, y_train)\n",
+    "y_train_pred_catboost = catboost_model.predict(X_train_scaled)\n",
+    "\n",
+    "# Training set metrics for CatBoost\n",
+    "print(\"Train MSE (CatBoost):\", mean_squared_error(y_train, y_train_pred_catboost))\n",
+    "print(\"Train R2 (CatBoost):\", r2_score(y_train, y_train_pred_catboost))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 419,
+   "id": "ba049cc9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test MSE (CatBoost): 12.513514213776878\n",
+      "Test R2 (CatBoost): 0.7093334031950302\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Check the metrics for catboost model for test set\n",
+    "y_pred_test_catboost = catboost_model.predict(X_test_scaled)\n",
+    "\n",
+    "# Calculate metrics on test set\n",
+    "test_mse_catboost = mean_squared_error(y_test, y_pred_test_catboost)\n",
+    "test_r2_catboost = r2_score(y_test, y_pred_test_catboost)\n",
+    "\n",
+    "print(\"Test MSE (CatBoost):\", test_mse_catboost)\n",
+    "print(\"Test R2 (CatBoost):\", test_r2_catboost)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 420,
+   "id": "d016f169",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0wAAAIhCAYAAAB9gDqHAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZcJJREFUeJzt3Xd809X+x/F3Ct0jjFBooZRVllipoohoEXABKioigqMgDhQHelXgooLKVK+LK66rFcQtqIiKyhJQEJAll2HZXAtiEdKW0qbj/P7g10ho00XbNOnr+XjkIf1+T775JE2+5t1zvudYjDFGAAAAAIAi/DxdAAAAAADUVAQmAAAAAHCDwAQAAAAAbhCYAAAAAMANAhMAAAAAuEFgAgAAAAA3CEwAAAAA4AaBCQAAAADcIDABAAAAgBsEJqAWeOedd2SxWJy3unXrKioqSjfeeKNSUlKq7HEnTJggi8VSprYtWrTQ0KFDq6yW8tbjaS1atHD5nYWFhalr166aNWtWtTx+4Xtmz549zm0XX3yxLr744nIfa/Lkyfr8888rrbZCe/bskcVi0TvvvOO2zYMPPiiLxaJt27a5bTNu3DhZLBatW7euzI9dHe/X0/XUU0+pY8eOKigocNmenp6uSZMmqUuXLoqIiFBgYKBatGih2267rVyvQaHU1FRNmDBBGzZsKLKv8DNXePPz81NUVJT69u2rH3/8saJPrdKUVHtxli5d6nwu7t53vXr1ksViUYsWLSqtTun03nMWi0UTJkxw/rxo0SKFhYXp999/r5ziAB9HYAJqkeTkZK1cuVILFy7Uvffeq3nz5unCCy/UkSNHquTxbr/9dq1cubJKjl0bdO/eXStXrtTKlSudASYpKUmvvvqqR+qZMWOGZsyYUe77VVVgKovhw4dLkt5+++1i9xcUFGjWrFnq3Lmzzj777OosrUqlpqbqmWee0VNPPSU/v7//V79z504lJCRo6tSp6tmzpz744AN99913evLJJ/XHH3/onHPOkd1uL/djPfnkkyWGjgULFmjlypVasWKFXnjhBR08eFAXX3xxhQJaZSpL7cUJDw/XW2+9VWT77t27tXTpUkVERFRShVWjd+/eOu+88/TPf/7T06UAXqGupwsAUH06deqkLl26SDrRW5Cfn6/x48fr888/17Bhwyr98Zo1a6ZmzZpV+nFri3r16un88893/nzJJZcoNjZWzz//vO6+++5i75Ofn6+8vDwFBgZWej0dO3as9GNWtU6dOum8887Tu+++q8mTJ6tuXdf/7X333Xf63//+p9GjR3uowqrx0ksvqV69erruuuuc2/Lz83XttdcqLS1NK1euVKdOnZz7evTooaSkJH3zzTfy9/ev9HrOOecc2Ww2SdIFF1yg8847T61bt9ann37qlUF10KBB+s9//qOUlBTFxcU5t7/99ttq2rSpzjzzTG3ZssWDFZZu5MiRGjRokCZOnKiYmBhPlwPUaPQwAbVYYXj6448/XLavXbtWV199tRo0aKCgoCAlJCTo448/dmmTlZWlhx9+WC1btlRQUJAaNGigLl266IMPPnC2KW4IXG5urh599FE1adJEISEhuvDCC7V69eoitbkbPlfcULGPPvpIl112maKiohQcHKwOHTpozJgxOnbsWKmvweLFi3XxxRerYcOGCg4OVvPmzTVgwABlZWW5vc8111yj2NjYIkOdJKlr164uXwA/+eQTde3aVVarVSEhIWrVqpVuu+22UusqTr169dSuXTvt3btX0t9D0p555hlNnDhRLVu2VGBgoJYsWSKpbL9HSVq1apW6d++uoKAgRUdHa+zYscrNzS3SrrgheTk5OXrqqafUoUMHBQUFqWHDhurZs6d++uknSSeGAh07dkwzZ850DmU6+RgHDx7UXXfdpWbNmikgIEAtW7bUk08+qby8PJfHSU1N1Q033KDw8HBZrVYNGjRIBw8eLNPrNnz4cB08eFDffPNNkX3JyckKDAzUTTfdpOzsbP3jH/9Q586dZbVa1aBBA3Xr1k1ffPFFqY9R3PtS+nsI19KlS122L1y4UL1791ZERIRCQkLUvXt3LVq0yKXNn3/+qTvvvFMxMTEKDAxUo0aN1L17dy1cuLDEWhwOh9566y0NGTLEpXfp888/16+//qqxY8e6hKWT9enTRyEhIZKkHTt2aNiwYYqLi1NISIiaNm2qq666Sr/++qvL8zv33HMlScOGDXP+jk8e/lUcq9UqSUXC2b59+3TzzTcrMjJSgYGB6tChg/71r38V+az99ddfuueee9S0aVMFBASoVatWGjdunHJyclzalfT5q2jtknTppZcqJibGpeeyoKBAM2fOVFJSksvrXig7O1tjx45Vy5YtFRAQoKZNm2rkyJE6evSoS7uyniOlsn9+inPVVVcpLCxMb775ZqltgdqOHiagFtu9e7ckqW3bts5tS5Ys0RVXXKGuXbvqtddek9Vq1YcffqhBgwYpKyvLOYb+oYce0rvvvquJEycqISFBx44d0+bNm3X48OESH/OOO+7QrFmz9PDDD+vSSy/V5s2bdd111ykjI6PCzyMlJUV9+/bVqFGjFBoaqm3btmnatGlavXq1Fi9e7PZ+e/bsUb9+/XTRRRfp7bffVr169fT7779rwYIFcjgczi+Op7rtttvUv39/LV68WJdccolz+7Zt27R69Wq9/PLLkqSVK1dq0KBBGjRokCZMmKCgoCDt3bu3xJpKkpubq71796pRo0Yu219++WW1bdtWzz33nCIiIhQXF1fm3+OWLVvUu3dvtWjRQu+8845CQkI0Y8YMvf/++6XWk5eXpz59+mj58uUaNWqUevXqpby8PK1atUr79u3TBRdcoJUrV6pXr17q2bOnHn/8cUlyDlc6ePCgzjvvPPn5+emJJ55Q69attXLlSk2cOFF79uxRcnKyJOn48eO65JJLlJqaqilTpqht27b66quvNGjQoDK9boMHD9aDDz6ot99+W1dddZVz+5EjR/TFF1/o2muvVf369WW32/XXX3/p4YcfVtOmTeVwOLRw4UJdd911Sk5O1q233lqmxyvN7Nmzdeutt6p///6aOXOm/P399frrr+vyyy/Xt99+q969e0uSbrnlFq1bt06TJk1S27ZtdfToUa1bt67Uz9jPP/+sw4cPq2fPni7bv/vuO0knAn9ZpKamqmHDhpo6daoaNWqkv/76SzNnzlTXrl21fv16tWvXTmeffbaSk5M1bNgwPfbYY+rXr58kFelZLuz5LCgo0L59+/TYY48pMDBQ119/vbPNn3/+qQsuuEAOh0NPP/20WrRoofnz5+vhhx/Wzp07ncNBs7Oz1bNnT+3cuVNPPvmk4uPjtXz5ck2ZMkUbNmzQV199Jan0z19Zay+On5+fhg4dqrfeeksTJ05UnTp1nL2Vw4YN0wMPPODS3hija665RosWLdLYsWN10UUXadOmTRo/frxz2G1hr3BZz5Fl/fy4ExAQoAsuuEBfffWVnnrqqVKfM1CrGQA+Lzk52Ugyq1atMrm5uSYjI8MsWLDANGnSxCQmJprc3Fxn2/bt25uEhASXbcYYc+WVV5qoqCiTn59vjDGmU6dO5pprrinxccePH29OPs1s3brVSDIPPvigS7v33nvPSDJJSUlu73vqc9m9e3exj1lQUGByc3PNDz/8YCSZjRs3uj3mp59+aiSZDRs2lPg8TpWbm2saN25shgwZ4rL90UcfNQEBASYtLc0YY8xzzz1nJJmjR4+W6/jGGBMbG2v69u1rcnNzTW5urtm9e7dJSkoykswjjzxijDFm9+7dRpJp3bq1cTgcLvcv6+9x0KBBJjg42Bw8eNDZJi8vz7Rv377I69yjRw/To0cP58+zZs0yksybb75Z4nMJDQ11+d0Wuuuuu0xYWJjZu3evy/bC1+2///2vMcaYV1991UgyX3zxhUu7O+64w0gyycnJJT6+McYkJSUZf39/88cffzi3TZ8+3Ugy33//fbH3ycvLM7m5uWb48OEmISHBZV9sbKzLc3L3vlyyZImRZJYsWWKMMebYsWOmQYMG5qqrrnJpl5+fb8466yxz3nnnObeFhYWZUaNGlfrcTjVt2jQjyeV3aowxV1xxhZFksrOzy31MY068Hg6Hw8TFxbl8htesWeP291D4mTv1FhERYebOnevSdsyYMUaS+fnnn12233333cZisZjt27cbY4x57bXXjCTz8ccfF/u8v/vuO2NM2T5/JdVenMLf5yeffGJ27dplLBaLmT9/vjHGmIEDB5qLL77YGGNMv379TGxsrPN+CxYsMJLMM88843K8jz76yEgyb7zxhjGmfOfIsn5+jDFGkhk/fnyR5zNu3Djj5+dnMjMzy/T8gdqKIXlALXL++efL399f4eHhuuKKK1S/fn198cUXzus6duzYoW3btummm26SdKIHofDWt29fHThwQNu3b5cknXfeefrmm280ZswYLV26VMePHy/18QuHihUev9ANN9xQ5NqS8ti1a5eGDBmiJk2aqE6dOvL391ePHj0kSVu3bnV7v86dOysgIEB33nmnZs6cqV27dpXp8erWraubb75Zc+fOdV4gn5+fr3fffVf9+/dXw4YNJck53OeGG27Qxx9/XO4Zqb7++mv5+/vL399fLVu21Mcff6z77rtPEydOdGl39dVXuwxtKs/vccmSJerdu7caN27svH+dOnXK1HvzzTffKCgoqMJDDOfPn6+ePXsqOjrapcY+ffpIkn744QdnjeHh4br66qtd7j9kyJAyP9bw4cOVm5urd99917ktOTlZsbGxzh4d6cQQru7duyssLEx169aVv7+/3nrrrRLfR+Xx008/6a+//lJSUpLLcy4oKNAVV1yhNWvWOIeSnnfeeXrnnXc0ceJErVq1qthhksVJTU2VxWJxXjNUUXl5eZo8ebI6duyogIAA1a1bVwEBAUpJSSn367Fw4UKtWbNGq1ev1vz583XJJZfoxhtv1GeffeZss3jxYnXs2FHnnXeey32HDh0qY4yzZ2jx4sUKDQ116Z0qbCfJObTxdD9/pWnZsqUuvvhivf322zp8+LC++OILt5+FwtpPneVu4MCBCg0NddZcnnNkWT8/JYmMjFRBQUGZh7cCtRWBCahFZs2apTVr1mjx4sW66667tHXrVg0ePNi5v/Bapocfftj5Rb3wds8990iS0tLSJJ0YBjZ69Gh9/vnn6tmzpxo0aKBrrrmmxGnKC4cSNWnSxGV73bp1nSGjvDIzM3XRRRfp559/1sSJE7V06VKtWbNGc+fOlaQSg1zr1q21cOFCRUZGauTIkWrdurVat26tl156qdTHve2225Sdna0PP/xQkvTtt9/qwIEDLpNnJCYm6vPPP1deXp5uvfVWNWvWTJ06dXK5zqskF154odasWaO1a9dqy5YtOnr0qF5++WUFBAS4tIuKinL5uTy/x8OHDxf5fUhFf0fF+fPPPxUdHV3s9Rpl8ccff+jLL78sUuMZZ5xRpMaTA115aix00UUXqW3bts5hSps2bdK6deuc165I0ty5c3XDDTeoadOmmj17tlauXKk1a9Y4f9eVofB3c/311xd53tOmTZMxRn/99ZekE9fmJSUl6T//+Y+6deumBg0a6NZbby31y+3x48fl7++vOnXquGxv3ry5pL+H4pbmoYce0uOPP65rrrlGX375pX7++WetWbNGZ511Vpn+QHKys846S126dNG5556rfv366ZNPPlGbNm00cuRIZ5vDhw8XeS9LUnR0tHN/4X+bNGlS5BrHyMhI1a1b19nudD9/ZTF8+HB9+eWXev755xUcHFwkxJ383OrWrVtkOK3FYlGTJk1cnptUtnNkWT8/JQkKCpJU8nkSANcwAbVKhw4dnBM99OzZU/n5+frPf/6jTz/9VNdff73zL9Jjx451mV3rZO3atZMkhYaG6sknn3ROR1zY23TVVVe5XfOm8H/4Bw8eVNOmTZ3b8/LyilyXUfg/8pycHJcZ3079ErB48WKlpqZq6dKlzl4lSUUupHbnoosu0kUXXaT8/HytXbtW06dP16hRo9S4cWPdeOONbu9X+Jfw5ORk3XXXXUpOTlZ0dLQuu+wyl3b9+/dX//79lZOTo1WrVmnKlCkaMmSIWrRooW7dupVYm9Vqdf6+SnLqF8fy/B4bNmxY7BfwsvzFuVGjRlqxYoUKCgoqFJpsNpvi4+M1adKkYvcXflFu2LBhsRe9l/ev4rfddpvGjBmj1atX6/3333deh1Jo9uzZatmypT766COX1/TUiQSKc/L79WSnvl8LfzfTp093mQHxZIXh0Gaz6cUXX9SLL76offv2ad68eRozZowOHTqkBQsWuK3FZrPJ4XDo2LFjCg0NdW6//PLL9cYbb+jzzz/XmDFjSn1OhddaTZ48uchzqlevXqn3L4mfn5/OOOMMffLJJzp06JAiIyPVsGFDHThwoEjb1NRU5/OSTrwffv75ZxljXH5Phw4dUl5enkvP2ul8/sriuuuu08iRIzV16lTdcccdCg4OLrZdw4YNlZeXpz///NMlNBljdPDgQWdvWHnOkWX9/JSkMJyfbm8k4OvoYQJqsWeeeUb169fXE088oYKCArVr105xcXHauHGjunTpUuwtPDy8yHEaN26soUOHavDgwdq+fbvbGeYKZ0d77733XLZ//PHHRWZ1Klz0cdOmTS7bv/zyS5efC78wnTqN9uuvv17ykz9FnTp11LVrV73yyiuSVKb1YYYNG6aff/5ZK1as0JdffqmkpKQif9UvFBgYqB49emjatGmSpPXr15ervvIoz++xZ8+eWrRokctMifn5+froo49KfZw+ffooOzu7xIVjpRPPvbi/YF955ZXavHmzWrduXWyNhV/4evbsqYyMDM2bN8/l/mWZmOJkSUlJqlu3rl5//XW999576t27t2JjY537LRaLAgICXL6EHzx4sEyz5Ll7v55ac/fu3VWvXj1t2bLF7e/m1B5E6UTv0L333qtLL7201Pdm+/btJZ1Yc+lk/fv315lnnqkpU6Zo8+bNxd7322+/dX5+LRZLkc/VV199VWRoW2Gb8vRS5Ofn69dff1VgYKBzEpDevXtry5YtRZ7frFmzZLFYnJNY9O7dW5mZmUXW9ipc1PnkIZYn11jc568itZ8sODhYTzzxhK666iq3U/2fXNPs2bNdts+ZM0fHjh1z7i/PObKsn5+S7Nq1Sw0bNiy2BxfA3+hhAmqx+vXra+zYsXr00Uf1/vvv6+abb9brr7+uPn366PLLL9fQoUPVtGlT/fXXX9q6davWrVunTz75RNKJ6bOvvPJKxcfHq379+tq6daveffdddevWze3sch06dNDNN9+sF198Uf7+/rrkkku0efNm5+xuJ+vbt68aNGig4cOH66mnnlLdunX1zjvvaP/+/S7tLrjgAtWvX18jRozQ+PHj5e/vr/fee08bN24s9fm/9tprWrx4sfr166fmzZsrOzvbOU3wybPfuTN48GA99NBDGjx4sHJycopcn/DEE0/of//7n3r37q1mzZrp6NGjeumll1yusaoqZf09PvbYY5o3b5569eqlJ554QiEhIXrllVfKNCX74MGDlZycrBEjRmj79u3q2bOnCgoK9PPPP6tDhw7OHrozzzxTS5cu1ZdffqmoqCiFh4erXbt2euqpp/T999/rggsu0P3336927dopOztbe/bs0ddff63XXntNzZo106233qoXXnhBt956qyZNmqS4uDh9/fXX+vbbb8v1mjRp0kR9+/ZVcnKyjDHORW0LXXnllZo7d67uueceXX/99dq/f7+efvppRUVFlTjUVDpxvUy7du308MMPKy8vT/Xr19dnn32mFStWuLQLCwvT9OnTlZSUpL/++kvXX3+9IiMj9eeff2rjxo36888/9eqrr8put6tnz54aMmSI2rdvr/DwcK1Zs0YLFixw22tYqPBL96pVqxQfH+/cXqdOHX322We67LLL1K1bN919993q2bOnQkNDtXfvXn366af68ssvnQtZX3nllXrnnXfUvn17xcfH65dfftGzzz5bZBa51q1bKzg4WO+99546dOigsLAwRUdHu3xh/+WXX5xTif/xxx96++23tW3bNj344IPO3rkHH3xQs2bNUr9+/fTUU08pNjZWX331lWbMmKG7777bOZvnrbfeqldeeUVJSUnas2ePzjzzTK1YsUKTJ09W3759nZ/dsnz+ylJ7aR566CE99NBDJba59NJLdfnll2v06NFKT09X9+7dnbPkJSQk6JZbbpFUvnNkWT8/JVm1apV69OhR7BIOAE7i0SknAFSLwhm81qxZU2Tf8ePHTfPmzU1cXJzJy8szxhizceNGc8MNN5jIyEjj7+9vmjRpYnr16mVee+015/3GjBljunTpYurXr28CAwNNq1atzIMPPuicIc6Y4me6y8nJMf/4xz9MZGSkCQoKMueff75ZuXJlkVnHjDFm9erV5oILLjChoaGmadOmZvz48eY///lPkdnIfvrpJ9OtWzcTEhJiGjVqZG6//Xazbt26IrNfnVrPypUrzbXXXmtiY2NNYGCgadiwoenRo4eZN29emV/bIUOGGEmme/fuRfbNnz/f9OnTxzRt2tQEBASYyMhI07dvX7N8+fJSjxsbG2v69etXYpvCWfKeffbZYveX5fdojDE//vijOf/8801gYKBp0qSJeeSRR8wbb7xR6ix5xpx4/zzxxBMmLi7OBAQEmIYNG5pevXqZn376ydlmw4YNpnv37iYkJMRIcjnGn3/+ae6//37TsmVL4+/vbxo0aGDOOeccM27cOJeZu/73v/+ZAQMGmLCwMBMeHm4GDBhgfvrpp3LNcGaMMV988YWRZBo0aFDsbHFTp041LVq0MIGBgaZDhw7mzTffLPZ9XNz79bfffjOXXXaZiYiIMI0aNTL33Xef+eqrr1xmySv0ww8/mH79+pkGDRoYf39/07RpU9OvXz/zySefGGOMyc7ONiNGjDDx8fEmIiLCBAcHm3bt2pnx48ebY8eOlfo8L7roItO3b99i9x09etQ8/fTT5uyzzzZhYWHG39/fNG/e3Nx8883mxx9/dLY7cuSIGT58uImMjDQhISHmwgsvNMuXLy/2ffDBBx+Y9u3bG39/f5cZ2YqbJa9Bgwama9eu5u2333bO1lho7969ZsiQIaZhw4bG39/ftGvXzjz77LNF2h0+fNiMGDHCREVFmbp165rY2FgzduxYl99pWT9/7movzsmz5JXk1FnyjDnxWRk9erSJjY01/v7+Jioqytx9993myJEjLu3Kc44s6+enuOe1Y8cOI8nMmTOnxOcCwBiLMcZUZ0ADAABVa86cORo0aJD27t3rci0MUOjxxx/XrFmztHPnztOapRSoDQhMAAD4GGOMLrjgAp1zzjn697//7elyUMMcPXpUrVq10vTp04tMYQ6gKCZ9AADAx1gsFr355puKjo5WQUGBp8tBDbN7926NHTu2XGuZAbUZPUwAAAAA4AY9TAAAAADgBoEJAAAAANwgMAEAAACAG7VqHsmCggKlpqYqPDycRdoAAACAWswYo4yMDEVHR8vPz30/Uq0KTKmpqYqJifF0GQAAAABqiP3796tZs2Zu99eqwBQeHi7pxIsSERHh4WoAAAAAeEp6erpiYmKcGcGdWhWYCofhRUREEJgAAAAAlHqpDpM+AAAAAIAbBCYAAAAAcMNrAlNeXp4ee+wxtWzZUsHBwWrVqpWeeuopFRQUeLo0AAAAAD7Ka65hmjZtml577TXNnDlTZ5xxhtauXathw4bJarXqgQce8HR5AAAAAHyQ1wSmlStXqn///urXr58kqUWLFvrggw+0du1aD1cGAAAAwFd5zZC8Cy+8UIsWLdJvv/0mSdq4caNWrFihvn37ur1PTk6O0tPTXW4AAAAAUFZe08M0evRo2e12tW/fXnXq1FF+fr4mTZqkwYMHu73PlClT9OSTT1ZjlQAAAAB8idf0MH300UeaPXu23n//fa1bt04zZ87Uc889p5kzZ7q9z9ixY2W32523/fv3V2PFAAAAALydxRhjPF1EWcTExGjMmDEaOXKkc9vEiRM1e/Zsbdu2rUzHSE9Pl9Vqld1uZ+FaAAAAoBYrazbwmh6mrKws+fm5llunTh2mFQcAAABQZbzmGqarrrpKkyZNUvPmzXXGGWdo/fr1ev7553Xbbbd5ujQAAAAAPsprhuRlZGTo8ccf12effaZDhw4pOjpagwcP1hNPPKGAgIAyHYMheQAAAACksmcDrwlMlYHABAAAAEDywWuYAAAAAKC6ec01TAAAoGT2LIfSMh1Kz85VRLC/bKEBsoaUbdg6AKB4BCYAAHxA6tHjGj1nk5anpDm3JcbZNHVAvKLrBXuwMgDwbgzJAwDAy9mzHEXCkiQtS0nTmDmbZM9yeKgyAPB+BCYAALxcWqajSFgqtCwlTWmZBCYAqCgCEwAAXi49O7fE/Rml7AcAuEdgAgDAy0UE+Ze4P7yU/QAA9whMAAB4OVtYgBLjbMXuS4yzyRbGTHkAUFEEJgAAvJw1JEBTB8QXCU2JcTZNGxDP1OIAcBqYVhwAAB8QXS9Y0wcnKC3ToYzsXIUH+csWxjpMAHC6CEwAAPgIawgBCQAqG0PyAAAAAMANAhMAAAAAuEFgAgAAAAA3CEwAAAAA4AaBCQAAAADcIDABAAAAgBsEJgAAAABwg8AEAAAAAG4QmAAAAADADQITAAAAALhBYAIAAAAANwhMAAAAAOAGgQkAAAAA3CAwAQAAAIAbBCYAAAAAcIPABAAAAABuEJgAAAAAwA0CEwAAAAC4QWACAAAAADfqeroAAAAAVD57lkNpmQ6lZ+cqIthfttAAWUMCPF0W4HUITAAAAD4m9ehxjZ6zSctT0pzbEuNsmjogXtH1gj1YGeB9GJIHAADgQ+xZjiJhSZKWpaRpzJxNsmc5PFQZ4J0ITAAAAD4kLdNRJCwVWpaSprRMAhNQHgQmAAAAH5KenVvi/oxS9gNwRWACAADwIRFB/iXuDy9lPwBXBCYAAAAfYgsLUGKcrdh9iXE22cKYKQ8oDwITAACAD7GGBGjqgPgioSkxzqZpA+KZWhwoJ6YVBwAA8DHR9YI1fXCC0jIdysjOVXiQv2xhrMMEVASBCQAAwAdZQwhIQGVgSB4AAAAAuOFVgen333/XzTffrIYNGyokJESdO3fWL7/84umyAAAAAPgorxmSd+TIEXXv3l09e/bUN998o8jISO3cuVP16tXzdGkAAAAAfJTXBKZp06YpJiZGycnJzm0tWrTwXEEAAAAAfJ7XDMmbN2+eunTpooEDByoyMlIJCQl68803S7xPTk6O0tPTXW4AAAAAUFZeE5h27dqlV199VXFxcfr22281YsQI3X///Zo1a5bb+0yZMkVWq9V5i4mJqcaKAQAAAHg7izHGeLqIsggICFCXLl30008/Obfdf//9WrNmjVauXFnsfXJycpSTk+P8OT09XTExMbLb7YqIiKjymgEAAADUTOnp6bJaraVmA6/pYYqKilLHjh1dtnXo0EH79u1ze5/AwEBFRES43AAAAACgrLwmMHXv3l3bt2932fbbb78pNjbWQxUBAAAA8HVeE5gefPBBrVq1SpMnT9aOHTv0/vvv64033tDIkSM9XRoAAAAAH+U1gencc8/VZ599pg8++ECdOnXS008/rRdffFE33XSTp0sDAAAA4KO8ZtKHylDWC7sAAAAA+Dafm/QBAAAAAKobgQkAAAAA3CAwAQAAAIAbBCYAAAAAcIPABAAAAABuEJgAAAAAwA0CEwAAAAC4QWACAAAAADcITAAAAADgBoEJAAAAANwgMAEAAACAGwQmAAAAAHCjrqcLAAAAAHyRPcuhtEyH0rNzFRHsL1togKwhAZ4uC+VEYAIAAAAqWerR4xo9Z5OWp6Q5tyXG2TR1QLyi6wV7sDKUF0PyAAAAgEpkz3IUCUuStCwlTWPmbJI9y+GhylARBCYAAACgEqVlOoqEpULLUtKUlklg8iYEJgAAAKASpWfnlrg/o5T9qFkITAAAAEAligjyL3F/eCn7UbMQmAAAAIBKZAsLUGKcrdh9iXE22cKYKc+bEJgAAACASmQNCdDUAfFFQlNinE3TBsQztbiXYVpxAECVYh0SALVRdL1gTR+coLRMhzKycxUe5C9bGOc/b0RgAgBUGdYhAVCbWUMISL6AIXkAgCrBOiQAAF9AYAIAVAnWIQEA+AICEwCgSrAOCQDAFxCYAABVgnVIAAC+gMAEAKgSrEMCAPAFBCYAQJVgHRIAgC9gWnEAQJVhHRIAgLcjMAEAqhTrkAAAvBlD8gAAAADADQITAAAAALhBYAIAAAAANwhMAAAAAOAGgQkAAAAA3CAwAQAAAIAbBCYAAAAAcIPABAAAAABuEJgAAAAAwA0CEwAAAAC4QWACAAAAADe8NjBNmTJFFotFo0aN8nQpAAAAAHyUVwamNWvW6I033lB8fLynSwEAAADgw7wuMGVmZuqmm27Sm2++qfr163u6HAAAAAA+zOsC08iRI9WvXz9dcsklpbbNyclRenq6yw0AAAAAyqqupwsojw8//FDr1q3TmjVrytR+ypQpevLJJ6u4KgAAAAC+ymt6mPbv368HHnhAs2fPVlBQUJnuM3bsWNntdudt//79VVwlAAAAAF9iMcYYTxdRFp9//rmuvfZa1alTx7ktPz9fFotFfn5+ysnJcdlXnPT0dFmtVtntdkVERFR1yQAAAABqqLJmA68Zkte7d2/9+uuvLtuGDRum9u3ba/To0aWGJQAAAAAoL68JTOHh4erUqZPLttDQUDVs2LDIdgAAAACoDF5zDRMAAAAAVDev6WEqztKlSz1dAgAAAAAfRg8TAAAAALhBYAIAAAAANwhMAAAAAOAGgQkAAAAA3CAwAQAAAIAbBCYAAAAAcMOrpxUHAMCX2LMcSst0KD07VxHB/rKFBsgaEuDpsgCgViMwAQBQA6QePa7RczZpeUqac1tinE1TB8Qrul6wBysDgNqNIXkAAHiYPctRJCxJ0rKUNI2Zs0n2LIeHKgMAEJgAAPCwtExHkbBUaFlKmtIyCUwA4CkMyQMAwMPSs3NL3J9Ryn6J658AoKoQmAAA8LCIIP8S94eXsp/rnwCg6jAkDwAAD7OFBSgxzlbsvsQ4m2xh7nuKfP36J3uWQzsPZWr9viPa+Wem1z8fAN6HHiYAADzMGhKgqQPiNWbOJi07pZdo2oD4EofWleX6J28dmkfPGYCagMAEAEANEF0vWNMHJygt06GM7FyFB/nLFlb6dUiVcf1TTVRaz9n0wQleGwQBeBcCEwAANYQ1pPwTNZzu9U81lS/3nAHwLlzDBACAFzud659qMl/tOQPgfQhMAAB4scLrn04NTWW5/qkm89WeMwDehyF5AAB4uYpe/1STFfacLStmWJ4395wB8D70MAEA4AOsIQFqHRmmzs3rq3VkmFeHJcl3e84AeB96mAAAQI3kiz1nALwPgQkAANRYFZk5EAAqE0PyAAAAAMANAhMAAAAAuEFgAgAAAAA3CEwAAAAA4AaBCQAAAADcIDABAAAAgBsEJgAAAABwg8AEAAAAAG6wcC0AAADgI+xZDqVlOpSenauIYH/ZQln8+XQRmAAAAAAfkHr0uEbP2aTlKWnObYlxNk0dEK/oesEerMy7MSQPAAAA8HL2LEeRsCRJy1LSNGbOJtmzHB6qzPsRmAAAAAAvl5bpKBKWCi1LSVNaJoGpoghMAAAAgJdLz84tcX9GKfvhHoEJAAAA8HIRQf4l7g8vZT/cIzABAAAAXs4WFqDEOFux+xLjbLKFMVNeRRGYAAAAAC9nDQnQ1AHxRUJTYpxN0wbEM7X4aWBacQAAAMAHRNcL1vTBCUrLdCgjO1fhQf6yhbEO0+kiMAEAAOC0sFhqzWEN4bWvbAQmAAAAVBiLpcLXec01TFOmTNG5556r8PBwRUZG6pprrtH27ds9XRYAAECtxWKpnmPPcmjnoUyt33dEO//M5LWuQl7Tw/TDDz9o5MiROvfcc5WXl6dx48bpsssu05YtWxQaGurp8gAAAGqdsiyWyvCwykevXvXymsC0YMECl5+Tk5MVGRmpX375RYmJiR6qCgAAoPZisdTqV1qv3vTBCYTUSuY1gelUdrtdktSgQQO3bXJycpSTk+P8OT09vcrrAgAAqC1YLLX60atX/bzmGqaTGWP00EMP6cILL1SnTp3ctpsyZYqsVqvzFhMTU41VAgAA+DYWS61+9OpVP68MTPfee682bdqkDz74oMR2Y8eOld1ud972799fTRUCAAD4PhZLrX706lU/rxuSd99992nevHlatmyZmjVrVmLbwMBABQYGVlNlAAAAtQ+LpVavwl69ZcUMy6NXr2p4TQ+TMUb33nuv5s6dq8WLF6tly5aeLgkAAAA60dPUOjJMnZvXV+vIMMJSFaJXr/p5TQ/TyJEj9f777+uLL75QeHi4Dh48KEmyWq0KDmb6RAAAANQOJ/fqHcvJlTU4QI78Ah1Mz1ZWbr5sofTwVSaLMcZ4uoiysFgsxW5PTk7W0KFDy3SM9PR0Wa1W2e12RUREVGJ1AAAAQNWzZzmUlulQenauIoL9FVTXT+Pn/VcLtx5ytqmMNZlOfRxfDGFlzQZe08PkJbkOAAAAPqgmBIjiFqy9sE1DDe3eUj/tPKwsR76k01+TiYVxXXlNYAIAAAA8oSYECHcL1q7YcVhG0m0XttS/F+9wbq/omkwsjFuU10z6AAAAUFH2LId2HsrU+n1HtPPPTNmzHJ4uCV6itABRXe+lkhas/XHHYSXE1CuyvSJrMpVlYdzahh4mAADg02pC7wC8V1kCRHX0uJS2YG1OXkGRbRVZk4mFcYuihwkAAPismtI7AO9VUwJEaQvWBtZ1/Vpf0TWZWBi3KAITAADwWQwvwumqKQGicMHa4lzYpqHW7z/q/Pl01mQq6XFq68K4DMkDAAA+q6b0DqDyVdesdYUBYlkxwbs6A0ThgrVj5mxyqSUxzqbJ154pR36BLmkfqfAgf9nCKv5alPQ4tXVhXAITAADwWTWldwCVqzqvS6tJAeLkBWszsnNPOxx5+nG8BYEJAAD4rJrSO4DK44lpr2tSgLCGVM/jVtfjeAOuYQIAAD6rsHfg1GsyavPwIm/nqevSrCEBah0Zps7N66t1ZBjvnVqEHiYAAODTalLvAE4f16WhuhGYAACAz2N4ke/gujRUNwITAACosOqaqQwoVFOvS6vMzwKfq5qFwAQAACqkOmcqAwrVpFnrClXmZ4HPVc1jMcYYTxdRXdLT02W1WmW32xUREeHpcgAA8Fr2LIfu/WB9sRffJ8bZqmSmMuBkhb0wnr4urTI/C3yuqldZswE9TAAAoNzKMlMZX+xQlWrKdWmV+Vngc1UzMa04AAAoN2YqA06ozM8Cn6uaicAEAADKjZnKgBMq87PA56pmIjABAIByK5yprDienKkMqG6V+Vngc1UzEZgAAEC5Fc5UduqXO0/OVAZ4QmV+Fvhc1UzMkgcAACqspsxUBnhaZX4W+FxVD2bJAwAAVa6mzFQGeFplfhb4XNUsDMkDAAAAADcITAAAAADgBoEJAAAAANwgMAEAAACAG0z6AAA+rHCmpfTsXEUE+8sWyoXEAACUB4EJAHxU6tHjGj1nk5anpDm3JcbZNHVAvKLrBXuwMgAAvAdD8gDAB9mzHEXCkiQtS0nTmDmbZM9yeKgyAAC8C4EJAHxQWqajSFgqtCwlTWmZBCYAAMqiUgJTfn6+NmzYoCNHjlTG4QAApyk9O7fE/Rml7AcAACdUKDCNGjVKb731lqQTYalHjx46++yzFRMTo6VLl1ZmfQCACogI8i9xf3gp+wEAwAkVCkyffvqpzjrrLEnSl19+qd27d2vbtm0aNWqUxo0bV6kFAgDKzxYWoMQ4W7H7EuNssoUxUx4AAGVRocCUlpamJk2aSJK+/vprDRw4UG3bttXw4cP166+/VmqBAIDys4YEaOqA+CKhKTHOpmkD4plaHACAMqrQtOKNGzfWli1bFBUVpQULFmjGjBmSpKysLNWpU6dSCwQAVEx0vWBNH5ygtEyHMrJzFR7kL1sY6zABAFAeFQpMw4YN0w033KCoqChZLBZdeumlkqSff/5Z7du3r9QCAQAVZw0hIAEAcDoqFJgmTJigTp06af/+/Ro4cKACAwMlSXXq1NGYMWMqtUAAAAAA8BSLMcZ4uojqkp6eLqvVKrvdroiICE+XAwAAAEg6seB4WqZD6dm5igj2ly2UEQJVrazZoMw9TC+//HKZH/z+++8vc1sAAACgNks9elyj52xyWXA8Mc6mqQPiFV0v2IOVQSpHD1PLli3LdkCLRbt27TqtoqoKPUwAAACoSexZDt37wXqXsFQoMc6m6YMT6GmqIpXew7R79+5KKQwAAADACWmZjmLDkiQtS0lTWqaDwORhFVqHCQAAAMDpS8/OLXF/Rin7UfUqNEueJP3vf//TvHnztG/fPjkcDpd9zz///GkX5s6MGTP07LPP6sCBAzrjjDP04osv6qKLLqqyxwMAAACqSkSQf4n7w0vZj6pXocC0aNEiXX311WrZsqW2b9+uTp06ac+ePTLG6Oyzz67sGp0++ugjjRo1SjNmzFD37t31+uuvq0+fPtqyZYuaN29eZY8LAAAAVAVbWIAS42xa5uYaJlsYw/E8rULTip933nm64oor9NRTTyk8PFwbN25UZGSkbrrpJl1xxRW6++67q6JWde3aVWeffbZeffVV57YOHTrommuu0ZQpU0q9v/PCrtTU4i/sqlNHCgr6++djx9wfzM9PCg6uWNusLMndy26xSCEhFWt7/LhUUOC+jtDQirXNzpby8yunbUjIibolKSdHysurnLbBwSdeZ0lyOKTcErqvy9M2KOjE+6K8bXNzT7R3JzBQqlu3/G3z8k68Fu4EBEj+/uVvm59/4nfnjr//ifblbVtQcOK9Vhlt69Y98VpIJz4TWVmV07Y8n3vOEcW35RxR/racI078m3NExdpyjjjxbx86Rxw4elxjvv5NP+w8Ikmqm5+ni1taNbF/JzUpbpY8zhHlb1vM5z49PV3W6OjSJ4QzFRAWFmZ27NhhjDGmXr16ZvPmzcYYYzZs2GBiY2MrcshS5eTkmDp16pi5c+e6bL///vtNYmJisffJzs42drvdedu/f7+RZOwnXqait759XQ8QElJ8O8mYHj1c29ps7tt26eLaNjbWfduOHV3bduzovu2pr3WXLu7b2myubXv0cN82JMS1bd++7tue+ha6/vqS22Zm/t02KanktocO/d32nntKbrt7999tH3645Lb//341xhgzfnzJbVev/rvtM8+U3HbJkr/b/vvfJbedP//vtsnJJbf9+OO/2378ccltk5P/bjt/fslt//3vv9suWVJy22ee+bvt6tUltx0//u+2mzeX3Pbhh/9uu3t3yW3vuefvtocOldw2KenvtpmZJbe9/nrjoqS2nCNO3DhH/H3jHHHixjnixI1zxIkb54i/b+U4R2R8853Z8UeGWb/3L3Noyr9KPi7niBO30zxH2CUjydjtdlOSCk36EBoaqpz/T5zR0dHauXOnc19aWvGzfJyutLQ05efnq3Hjxi7bGzdurIMHDxZ7nylTpshqtTpvMTExVVIbAAAAcDrCgvzVOjJMnZvXV6PwQE+Xg5NUaEjeNddco379+umOO+7Qo48+qs8++0xDhw7V3LlzVb9+fS1cuLDSC01NTVXTpk31008/qVu3bs7tkyZN0rvvvqtt27YVuU9OTo4z2EknhuTFxMQwJK+8belKL39bhtuc+DfDbSrWlnPEiX9zjih/W84RJ/7NOaJibTlHnPg354jyt/XSc0RZh+RVKDDt2rVLmZmZio+PV1ZWlh5++GGtWLFCbdq00QsvvKDY2NjyHrJUDodDISEh+uSTT3Tttdc6tz/wwAPasGGDfvjhh1KPwcK1AAAAAKQqWLj2ZK1atXL+OyQkRDNmzKjIYcolICBA55xzjr7//nuXwPT999+rf//+Vf74AAAAAGqfCq/D5AkPPfSQbrnlFnXp0kXdunXTG2+8oX379mnEiBGeLg0APMKe5VBapkPp2bmKCPaXLTSAFeEBAKhEFQpMfn5+shSOCS1GfkljT0/DoEGDdPjwYT311FM6cOCAOnXqpK+//rpKhgACQE2XevS4Rs/ZpOUnrd2RGGfT1AHxii5uGloANR5/BAFqngpdw/TFF1+4/Jybm6v169dr5syZevLJJzV8+PBKK7AycQ0TAF9hz3Lo3g/Wu4SlQolxNk0fnMCXLMDL1NY/ghAS4SllzQYVCkzuvP/++/roo4+KBKqagsAEwFfsPJSp3s+7n+xm0UM91DoyrBorAnA6ausfQWprSETNUNZsUKF1mNzp2rVrlUwpDgBwlZ5dwtS0kjJK2Q+gZknLdBQbliRpWUqa0jJLmDbaS9mzHEXCknTi+Y6Zs0n2LN97zvBOlRaYjh8/runTp6tZs2aVdUgAgBsRQf4l7g8vZT+AmqU2/hGkNoZEeKcKTfpQv359l0kfjDHKyMhQSEiIZs+eXWnFAQCKZwsLUGKcTcvcDN+xhfne0B3Al9XGP4LUxpDoCVwjdvoqFJheeOEFl8Dk5+enRo0aqWvXrqpfv36lFQcAKJ41JEBTB8RrzJxNLqEpMc6maQPi+Z8h4GVq4x9BamNIrG5cI1Y5KnXSh5qOSR8A+JrCvxxmZOcqPMhftjD+cgh4q9Sjx93+ESTKB7/c2rMcuu+D9W5Doq9OdFFdautEIuVR1mxQ5h6mTZs2lfnB4+Pjy9wWAFBx1hACEuArousFa/rghFrzRxB6yqtWWa4Rq67X2NuHBZY5MHXu3FkWi0WFHVKeWLgWAADAl9W2P4LUtpBYnWrKNWK+MCywzLPk7d69W7t27dLu3bs1d+5ctWzZUjNmzND69eu1fv16zZgxQ61bt9acOXOqsl4AAAD4EGtIgFpHhqlz8/pqHRlGWKokNeEaMV+ZOr7MPUyxsbHOfw8cOFAvv/yy+vbt69wWHx+vmJgYPf7447rmmmsqtUgAAAAAZVcTJhKpScMCT0eF1mH69ddf1bJlyyLbW7ZsqS1btpx2UQAAAAAqrvAascQ4m8v26rxGrKYMCzxdFZpWvEOHDpo4caLeeustBQUFSZJycnI0ceJEdejQoVILBAAAALxBTZvcwNPXiNWEYYGVoUKB6bXXXtNVV12lmJgYnXXWWZKkjRs3ymKxaP78+ZVaIAAAAFDT1dTJDTw5kUhNGBZYGSq8DlNWVpZmz56tbdu2yRijjh07asiQIQoNDa3sGisN6zABAACgsrHmkXs1eX2xSl+H6VQhISG68847K3p3AAAAwCd42+QG1Tl00NPDAitDmQPTvHnz1KdPH/n7+2vevHkltr366qtPuzAAAADAG3jT5AaeGDro7euLlTkwXXPNNTp48KAiIyNLnDbcYrGwcC0AAABqDW+Z3KC0dZFq89DBkpR5WvGCggJFRkY6/+3uRlgCAABAbVI4uUFxatLkBmUZOoiiKrQOU3GOHj1aWYcCAAAAvEZNWPOoLLxp6GBNUqFJH6ZNm6YWLVpo0KBBkqSBAwdqzpw5ioqK0tdff+2cahwAAACoDbxhcgNvGTpY01Soh+n1119XTEyMJOn777/XwoULtWDBAvXp00ePPPJIpRYIAAAAeANrSIBaR4apc/P6ah0ZVqPCkuQ9Qwdrmgr1MB04cMAZmObPn68bbrhBl112mVq0aKGuXbtWaoEAAAAATl/h0EF36yLVtIBXU1QoMNWvX1/79+9XTEyMFixYoIkTJ0qSjDFM+gCUoDrXPQAAADiVNwwdrGkqFJiuu+46DRkyRHFxcTp8+LD69OkjSdqwYYPatGlTqQUCvsIT6x4AAACcytvXRapuFbqG6YUXXtC9996rjh076vvvv1dYWJikE0P17rnnnkotEPAFpa17YM9iGk8AAICayGKMMZ4uorqkp6fLarXKbrcrIiLC0+WgFtl5KFO9n//B7f5FD/VQ68iwaqwIAACgditrNqjwOkzvvvuuLrzwQkVHR2vv3r2SpBdffFFffPFFRQ8J+CzWPQAAAPBOFQpMr776qh566CH16dNHR48edU70UK9ePb344ouVWR/gE1j3AAAAwDtVKDBNnz5db775psaNG6c6deo4t3fp0kW//vprpRUH+ArWPQAAAPBOFQpMu3fvVkJCQpHtgYGBOnbs2GkXBfiawnUPTg1NrHsAAABQs1VoWvGWLVtqw4YNio2Nddn+zTffqEOHDpVSGOBrWPcAAADA+1QoMD3yyCMaOXKksrOzZYzR6tWr9cEHH2jy5Ml66623KrtGwGew7gEAAIB3qVBgGjZsmPLy8vToo48qKytLQ4YMUdOmTTV9+nRddNFFlV0jAAAAAHhEhacVv+OOO7R3714dOnRIBw8e1OrVq7V+/Xq1adOmMusDAAAAAI8pV2A6evSobrrpJjVq1EjR0dF6+eWX1aBBA73yyitq06aNVq1apbfffruqagUAAABQQ9izHNp5KFPr9x3Rzj8zZc9yeLqkKlGuIXn//Oc/tWzZMiUlJWnBggV68MEHtWDBAmVnZ+vrr79Wjx49qqpOAAAAADVE6tHjGj1nk5anpDm3JcbZNHVAvKLrBXuwsspXrh6mr776SsnJyXruuec0b948GWPUtm1bLV68mLAEAAAA1AL2LEeRsCRJy1LSNGbOJp/raSpXYEpNTVXHjh0lSa1atVJQUJBuv/32KikMAAAAQM2TlukoEpYKLUtJU1pmLQ5MBQUF8vf3d/5cp04dhYaGVnpRAAAAAGqm9OzcEvdnlLLf25TrGiZjjIYOHarAwEBJUnZ2tkaMGFEkNM2dO7fyKgQAAABQY0QE+Ze4P7yU/d6mXIEpKSnJ5eebb765UosBAAAAULPZwgKUGGfTsmKG5SXG2WQLC/BAVVXHYowxni6iNHv27NHTTz+txYsX6+DBg4qOjtbNN9+scePGKSCg7L+Q9PR0Wa1W2e12RUREVGHFAAAAgO9KPXpcY+ZscglNiXE2TRsQryg3s+TZsxxKy3QoPTtXEcH+soUGyBriuXBV1mxQrh4mT9m2bZsKCgr0+uuvq02bNtq8ebPuuOMOHTt2TM8995ynywMAAABqleh6wZo+OEFpmQ5lZOcqPMhftjD3AcibpyH3ih6m4jz77LN69dVXtWvXrjLfhx4mAAAAoHrZsxy694P1xc6slxhn0/TBCR7pafKpHqbi2O12NWjQoMQ2OTk5ysnJcf6cnp5e1WUBAAAAOElZpiH35NC80pRrWvGaYufOnZo+fbpGjBhRYrspU6bIarU6bzExMdVUIQAAAADJ+6ch92hgmjBhgiwWS4m3tWvXutwnNTVVV1xxhQYOHFjqorljx46V3W533vbv31+VTwcAAADAKbx9GnKPDsm79957deONN5bYpkWLFs5/p6amqmfPnurWrZveeOONUo8fGBjoXDMKAACgNqppM5Oh9vH2acg9GphsNptsNluZ2v7+++/q2bOnzjnnHCUnJ8vPzytHEwIAAFQbb56ZDL7DGhKgqQPi3U5DXtMDvFfMkpeamqoePXqoefPmmjVrlurUqePc16RJkzIfh1nyAABAbVFTZyZD7VXY21mWacirg0/Nkvfdd99px44d2rFjh5o1a+ayzwvyHgAAQLXz9pnJ4HusId45HNQrxrUNHTpUxphibwAAACjK22cmA2oKrwhMAAAAKB9vn5kMqCkITAAAAD6ocGay4njDzGRATUFgAgAA8EGFM5OdGpq8ZWYyoKbwikkfAAAAUH7R9YI1fXBCjZqZDPA2BCYAAAAf5q0zkwE1BUPyAAAAAMANAhMAAAAAuEFgAgAAAAA3CEwAAAAA4AaBCQAAAADcYJY8AAAAnBZ7lkNpmQ6lZ+cqIthftlBm5oPvIDABAACgwlKPHtfoOZu0PCXNuS0xzqapA+IVXS/Yg5VVHgJh7UZgAgAA8CHV+eXenuUoEpYkaVlKmsbM2aTpgxO8PljUhkCIkhGYAAAAfER1f7lPy3QUCUuFlqWkKS3T4dWBqTYEQpSOSR8AAAB8QGlf7u1Zjkp/zPTs3BL3Z5Syv6YrSyCE7yMwAQAA+ABPfLmPCPIvcX94KftrOl8PhCgbAhMAAIAP8MSXe1tYgBLjbMXuS4yzyRbm3cPVPBUI7VkO7TyUqfX7jmjnn5lV0juIsuMaJgAAAB/giS/31pAATR0QrzFzNmnZKddNTRsQ7/XX9xQGwmXF9NxVVSBkkomax2KMMZ4uorqkp6fLarXKbrcrIiLC0+UAAABUGnuWQ/d9sN7tl/uqnKCgcGa+jOxchQf5yxbmO9Nupx497jYQRlVygLFnOXTvB+uLHVpZ1b/D2qis2YAeJgAAAB/gyd4ea4jvBKRTRdcL1vTBCdUSCH191kFvRWACAADwEdX55b42qa5AyCQTNROBCQAAwIf4cm+Pr/P1WQe9FbPkAQAAANXI3Sx4vj7roLeihwkAAACoJqXNgufLsw56K2bJAwAAAKpBWWfB8+VZB2sSZskDAAAAapCyzoLHdWg1C9cwAQAAANWAWfC8E4EJAAAAqAbMguedCEwAAABANWAWPO9EYAIAAACqgTUkQFMHxBcJTcyCV7Mx6QMAAABQTaLrBWv64ARmwfMiBCYAAACgGjELnndhSB4AAAAAuEFgAgAAAAA3CEwAAAAA4AaBCQAAAADcYNIHAAAAAE72LIfSMh1Kz85VRLC/bKG1e5IKAhMAAADgpSo73KQePa7RczZpeUqac1tinE1TB8Qrul5wZZTsdQhMAAAAgBeq7HBjz3IUOZ4kLUtJ05g5mzR9cEKt7GniGiYAAADAy5QWbuxZjnIfMy3TUeR4Jx83LbP8x/QFBCYAAADAy1RFuEnPzi1xf0Yp+32V1wWmnJwcde7cWRaLRRs2bPB0OQAAAEC1q4pwExHkX+L+8FL2+yqvC0yPPvqooqOjPV0GAAAA4DFVEW5sYQFKjLMVuy8xziZbWO27fknyssD0zTff6LvvvtNzzz3n6VIAAAAAj6mKcGMNCdDUAfFFjpsYZ9O0AfG1csIHyYtmyfvjjz90xx136PPPP1dISEiZ7pOTk6OcnBznz+np6VVVHgAAAFBtCsPNmDmbtOyUWfJOJ9xE1wvW9MEJSst0KCM7V+FB/rKFsQ5TjWeM0dChQzVixAh16dJFe/bsKdP9pkyZoieffLJqiwMAAAA8oKrCjTWkdgekU3l0SN6ECRNksVhKvK1du1bTp09Xenq6xo4dW67jjx07Vna73Xnbv39/FT0TAAAAoPpZQwLUOjJMnZvXV+vIMIJOFbAYY4ynHjwtLU1pacVPh1ioRYsWuvHGG/Xll1/KYrE4t+fn56tOnTq66aabNHPmzDI9Xnp6uqxWq+x2uyIiIk6rdgAAAADeq6zZwKOBqaz27dvncv1RamqqLr/8cn366afq2rWrmjVrVqbjEJgAAAAASGXPBl5xDVPz5s1dfg4LC5MktW7dusxhCQAAAADKy6umFQcAAACA6uQVPUynatGihbxgJCEAAAAAL0cPEwAAAAC4QWACAAAAADcITAAAAADgBoEJAAAAANwgMAEAAACAGwQmAAAAAHCDwAQAAAAAbnjlOkxAZbNnOZSW6VB6dq4igv1lCw2QNSTA02UBAADAwwhMqPVSjx7X6DmbtDwlzbktMc6mqQPiFV0v2IOVAQAAwNMYkodazZ7lKBKWJGlZSprGzNkke5bDQ5UBAACgJiAwoVZLy3QUCUuFlqWkKS2TwAQAAFCbEZhQq6Vn55a4P6OU/QAAAPBtBCbUahFB/iXuDy9lPwAAAHwbgQm1mi0sQIlxtmL3JcbZZAtjpjwAAIDajMCEWs0aEqCpA+KLhKbEOJumDYhnanEAAIBajmnFUetF1wvW9MEJSst0KCM7V+FB/rKFsQ4TAO/BWnIAUHUITIBO9DTx5QKAN2ItOQCoWgzJAwDAS7GWHABUPQITAABeirXkAKDqEZgAAPBSrCUHAFWPwAQAgJdiLTkAqHoEJgAAvBRryQFA1SMwAQDgpVhLDgCqHtOKAwDgxVhLDgCqFoEJAAAvx1pyAFB1CEwAAABAJbBnOZSW6VB6dq4igv1lC+WPGb6AwAQAAACcptSjx4ssJJ0YZ9PUAfGKrhfswcpwupj0AQAAADgN9ixHkbAknVhAesycTbJnsYi0NyMwAQAAAKchLdNRJCwVWpaSprRMApM3IzABAAAApyE9O7fE/Rml7EfNRmACAAAATkNEkH+J+8NL2Y+ajcAEAAAAnAZbWECRBaQLJcbZZAtjpjxvRmACAAAAToM1JEBTB8QXCU2JcTZNGxDP1OJejmnFAQAAgNMUXS9Y0wcnKC3ToYzsXIUH+csWxjpMvoDABAAAAFQCawgByRcxJA8AAAAA3CAwAQAAAIAbBCYAAAAAcIPABAAAAABuEJgAAAAAwA0CEwAAAAC44VWB6auvvlLXrl0VHBwsm82m6667ztMlAQAAAPBhXrMO05w5c3THHXdo8uTJ6tWrl4wx+vXXXz1dFgAAAAAf5hWBKS8vTw888ICeffZZDR8+3Lm9Xbt2Jd4vJydHOTk5zp/T09OrrEYAAAAAvscrhuStW7dOv//+u/z8/JSQkKCoqCj16dNH//3vf0u835QpU2S1Wp23mJiYaqoYAAAAgC/wisC0a9cuSdKECRP02GOPaf78+apfv7569Oihv/76y+39xo4dK7vd7rzt37+/ukoGAAAA4AM8GpgmTJggi8VS4m3t2rUqKCiQJI0bN04DBgzQOeeco+TkZFksFn3yySdujx8YGKiIiAiXGwAAAACUlUevYbr33nt14403ltimRYsWysjIkCR17NjRuT0wMFCtWrXSvn37qrRGAAAAALWXRwOTzWaTzWYrtd0555yjwMBAbd++XRdeeKEkKTc3V3v27FFsbGxVlwkAAACglvKKWfIiIiI0YsQIjR8/XjExMYqNjdWzzz4rSRo4cKCHqwMAAADgq7wiMEnSs88+q7p16+qWW27R8ePH1bVrVy1evFj169f3dGkAAAAAfJTFGGM8XUR1SU9Pl9Vqld1uZwIIAAAAoBYrazbwimnFAQAAAMATCEwAAAAA4AaBCQAAAADcIDABAAAAgBsEJgAAAABwg8AEAAAAAG4QmAAAAADADQITAAAAALhBYAIAAAAANwhMAAAAAOAGgQkAAAAA3CAwAQAAAIAbBCYAAAAAcIPABAAAAABuEJgAAAAAwA0CEwAAAAC4UdfTBQAAAAA1jT3LobRMh9KzcxUR7C9baICsIQGeLgseQGACAAAATpJ69LhGz9mk5Slpzm2JcTZNHRCv6HrBHqwMnsCQPAAAAOD/2bMcRcKSJC1LSdOYOZtkz3J4qDJ4CoEJAAAA+H9pmY4iYanQspQ0pWUSmGobAhMAAADw/9Kzc0vcn1HKfvgeAhMAAADw/yKC/EvcH17KfvgeAhMAAADw/2xhAUqMsxW7LzHOJlsYM+XVNgQmAAAA4P9ZQwI0dUB8kdCUGGfTtAHxTC1eCzGtOAAAAHCS6HrBmj44QWmZDmVk5yo8yF+2MNZhqq0ITAAAAMAprCEEJJzAkDwAAAAAcIPABAAAAABuEJgAAAAAwA0CEwAAAAC4QWACAAAAADcITAAAAADgBoEJAAAAANwgMAEAAACAGyxcCwAAgAqxZzmUlulQenauIoL9ZQtlsVf4HgITAAAAyi316HGNnrNJy1PSnNsS42yaOiBe0fWCPVgZULkYkgcAAIBysWc5ioQlSVqWkqYxczbJnuXwUGVA5SMwAQAAoFzSMh1FwlKhZSlpSsskMMF3EJgAAABQLunZuSXuzyhlP+BNCEwAAAAol4gg/xL3h5eyH/AmBCYAAACUiy0sQIlxtmL3JcbZZAtjpjz4Dq8JTL/99pv69+8vm82miIgIde/eXUuWLPF0WQAAALWONSRAUwfEFwlNiXE2TRsQz9Ti8CleM614v3791LZtWy1evFjBwcF68cUXdeWVV2rnzp1q0qSJp8sDAACoVaLrBWv64ASlZTqUkZ2r8CB/2cJYhwm+x2KMMZ4uojRpaWlq1KiRli1bposuukiSlJGRoYiICC1cuFC9e/cu9n45OTnKyclx/pyenq6YmBjZ7XZFRERUS+0AAAAAap709HRZrdZSs4FXDMlr2LChOnTooFmzZunYsWPKy8vT66+/rsaNG+ucc85xe78pU6bIarU6bzExMdVYNQAAAABv5xU9TJL0+++/q3///lq3bp38/PzUuHFjffXVV+rcubPb+9DDBAAAAKA4XtHDNGHCBFkslhJva9eulTFG99xzjyIjI7V8+XKtXr1a/fv315VXXqkDBw64PX5gYKAiIiJcbgAAAABQVh7tYUpLS1NaWvGrRBdq0aKFfvzxR1122WU6cuSIS+iJi4vT8OHDNWbMmDI9XllTJAAAAADfVtZs4NFZ8mw2m2y24ufwP1lWVpYkyc/PtUPMz89PBQUFVVIbAAAAAHjFpA/dunVT/fr1lZSUpI0bN+q3337TI488ot27d6tfv36eLg8AAACAj/KKwGSz2bRgwQJlZmaqV69e6tKli1asWKEvvvhCZ511lqfLAwAAAOCjvGaWvMrANUwAAAAAJC+ZJQ8AAAAAajICEwAAAAC4QWACAAAAADcITAAAAADgBoEJAAAAANzw6MK1tZU9y6G0TIfSs3MVEewvW2iArCEBni4LAAAAwCkITNUs9ehxjZ6zSctT0pzbEuNsmjogXtH1gj1YGQAAAIBTMSSvGtmzHEXCkiQtS0nTmDmbZM9yeKgyAAAAAMUhMFWjtExHkbBUaFlKmtIyCUwAAABATUJgqkbp2bkl7s8oZT8AAACA6kVgqkYRQf4l7g8vZT8AAACA6kVgqka2sAAlxtmK3ZcYZ5MtjJnyAAAAgJqEwFSNrCEBmjogvkhoSoyzadqAeKYWBwAAAGoYphWvZtH1gjV9cILSMh3KyM5VeJC/bGGswwQAAADURAQmD7CGEJAAAAAAb8CQPAAAAABwg8AEAAAAAG4QmAAAAADADQITAAAAALhBYAIAAAAANwhMAAAAAOAGgQkAAAAA3CAwAQAAAIAbBCYAAAAAcIPABAAAAABuEJgAAAAAwA0CEwAAAAC4QWACAAAAADcITAAAAADgRl1PF1CdjDGSpPT0dA9XAgAAAMCTCjNBYUZwp1YFpoyMDElSTEyMhysBAAAAUBNkZGTIarW63W8xpUUqH1JQUKDU1FSFh4fLYrF4rI709HTFxMRo//79ioiI8FgdqJ14/8HTeA/Ck3j/wZN4/9UsxhhlZGQoOjpafn7ur1SqVT1Mfn5+atasmafLcIqIiODDAo/h/QdP4z0IT+L9B0/i/VdzlNSzVIhJHwAAAADADQITAAAAALhBYPKAwMBAjR8/XoGBgZ4uBbUQ7z94Gu9BeBLvP3gS7z/vVKsmfQAAAACA8qCHCQAAAADcIDABAAAAgBsEJgAAAABwg8AEAAAAAG4QmKpIixYtZLFYitxGjhwpSRo6dGiRfeeff76Hq4YvycvL02OPPaaWLVsqODhYrVq10lNPPaWCggJnG2OMJkyYoOjoaAUHB+viiy/Wf//7Xw9WDV9Rlvcf50FUpYyMDI0aNUqxsbEKDg7WBRdcoDVr1jj3c/5DVSrt/cf5z7vU9XQBvmrNmjXKz893/rx582ZdeumlGjhwoHPbFVdcoeTkZOfPAQEB1VojfNu0adP02muvaebMmTrjjDO0du1aDRs2TFarVQ888IAk6ZlnntHzzz+vd955R23bttXEiRN16aWXavv27QoPD/fwM4A3K8v7T+I8iKpz++23a/PmzXr33XcVHR2t2bNn65JLLtGWLVvUtGlTzn+oUqW9/yTOf96EacWryahRozR//nylpKTIYrFo6NChOnr0qD7//HNPlwYfdeWVV6px48Z66623nNsGDBigkJAQvfvuuzLGKDo6WqNGjdLo0aMlSTk5OWrcuLGmTZumu+66y1OlwweU9v6TxHkQVeb48eMKDw/XF198oX79+jm3d+7cWVdeeaWefvppzn+oMqW9/yZOnMj5z8swJK8aOBwOzZ49W7fddpssFotz+9KlSxUZGam2bdvqjjvu0KFDhzxYJXzNhRdeqEWLFum3336TJG3cuFErVqxQ3759JUm7d+/WwYMHddlllznvExgYqB49euinn37ySM3wHaW9/wpxHkRVyMvLU35+voKCgly2BwcHa8WKFZz/UKVKe/8V4vznPRiSVw0+//xzHT16VEOHDnVu69OnjwYOHKjY2Fjt3r1bjz/+uHr16qVffvmF1Z9RKUaPHi273a727durTp06ys/P16RJkzR48GBJ0sGDByVJjRs3drlf48aNtXfv3mqvF76ltPefxHkQVSc8PFzdunXT008/rQ4dOqhx48b64IMP9PPPPysuLo7zH6pUae8/ifOftyEwVYO33npLffr0UXR0tHPboEGDnP/u1KmTunTpotjYWH311Ve67rrrPFEmfMxHH32k2bNn6/3339cZZ5yhDRs2aNSoUYqOjlZSUpKz3cm9ntKJC6FP3QaUV1nef5wHUZXeffdd3XbbbWratKnq1Kmjs88+W0OGDNG6deucbTj/oaqU9v7j/OddCExVbO/evVq4cKHmzp1bYruoqCjFxsYqJSWlmiqDr3vkkUc0ZswY3XjjjZKkM888U3v37tWUKVOUlJSkJk2aSDrR0xQVFeW836FDh4r81RUor9Lef8XhPIjK1Lp1a/3www86duyY0tPTFRUVpUGDBqlly5ac/1DlSnr/FYfzX83GNUxVLDk5WZGRkS4X/RXn8OHD2r9/v8uJGzgdWVlZ8vNz/YjXqVPHOa1z4ZeG77//3rnf4XDohx9+0AUXXFCttcL3lPb+Kw7nQVSF0NBQRUVF6ciRI/r222/Vv39/zn+oNsW9/4rD+a9mo4epChUUFCg5OVlJSUmqW/fvlzozM1MTJkzQgAEDFBUVpT179uif//ynbDabrr32Wg9WDF9y1VVXadKkSWrevLnOOOMMrV+/Xs8//7xuu+02SSeGoowaNUqTJ09WXFyc4uLiNHnyZIWEhGjIkCEerh7errT3H+dBVLVvv/1Wxhi1a9dOO3bs0COPPKJ27dpp2LBhnP9Q5Up6/3H+80IGVebbb781ksz27dtdtmdlZZnLLrvMNGrUyPj7+5vmzZubpKQks2/fPg9VCl+Unp5uHnjgAdO8eXMTFBRkWrVqZcaNG2dycnKcbQoKCsz48eNNkyZNTGBgoElMTDS//vqrB6uGryjt/cd5EFXto48+Mq1atTIBAQGmSZMmZuTIkebo0aPO/Zz/UJVKev9x/vM+rMMEAAAAAG5wDRMAAAAAuEFgAgAAAAA3CEwAAAAA4AaBCQAAAADcIDABAAAAgBsEJgAAAABwg8AEAAAAAG4QmAAAAADADQITAHixCRMmqHPnzs6fhw4dqmuuuaba69izZ48sFos2bNhQ7Y9dmosvvlijRo2qlseyWCz6/PPPq+WxaprFixerffv2KigoqPAx5s+fr4SEhNM6BgBUNgITAFSyoUOHymKxyGKxyN/fX61atdLDDz+sY8eOVfljv/TSS3rnnXfK1NYTIWfHjh267bbb1Lx5cwUGBqpp06bq3bu33nvvPeXl5VVbHafr1KBa6MCBA+rTp0+VPvY777zjfH9ZLBY1btxYV111lf773/+W+zj16tWrtLoeffRRjRs3Tn5+J75arF+/XgkJCQoLC9PVV1+tI0eOONvm5eXp7LPP1po1a1yOceWVV8pisej999+vtLoA4HQRmACgClxxxRU6cOCAdu3apYkTJ2rGjBl6+OGHi22bm5tbaY9rtVor9UtwZVq9erXOPvtsbd26Va+88oo2b96s+fPn67bbbtNrr71W4hf+ynyNqlKTJk0UGBhY5Y8TERGhAwcOKDU1VV999ZWOHTumfv36yeFwVPljF+enn35SSkqKBg4c6Nx2++23q1evXlq3bp2OHj2qyZMnO/c999xzuvDCC3XuuecWOdawYcM0ffr0aqkbAMqCwAQAVSAwMFBNmjRRTEyMhgwZoptuusk5VKuwd+Ltt99Wq1atFBgYKGOM7Ha77rzzTkVGRioiIkK9evXSxo0bXY47depUNW7cWOHh4Ro+fLiys7Nd9p86JK+goEDTpk1TmzZtFBgYqObNm2vSpEmSpJYtW0qSEhISZLFYdPHFFzvvl5ycrA4dOigoKEjt27fXjBkzXB5n9erVSkhIUFBQkLp06aL169eX+HoYYzR06FC1bdtWP/74o6666irFxcUpISFBN910k5YvX674+HhJf/d8ffzxx7r44osVFBSk2bNn6/Dhwxo8eLCaNWumkJAQnXnmmfrggw9cHufYsWO69dZbFRYWpqioKP3rX/8qUktxw+bq1avn0jM3evRotW3bViEhIWrVqpUef/xxZ2h755139OSTT2rjxo3OXp7C+5567F9//VW9evVScHCwGjZsqDvvvFOZmZnO/YW/r+eee05RUVFq2LChRo4cWWpAtFgsatKkiaKiotSlSxc9+OCD2rt3r7Zv3+5s8/zzz+vMM89UaGioYmJidM899zgfe+nSpRo2bJjsdrvzOUyYMEGS5HA49Oijj6pp06YKDQ1V165dtXTp0hLr+fDDD3XZZZcpKCjIuW3r1q2644471LZtWw0ePFhbtmyRJO3atUtvv/228314qquvvlqrV6/Wrl27SnxMAKguBCYAqAbBwcEuX4J37Nihjz/+WHPmzHEOievXr58OHjyor7/+Wr/88ovOPvts9e7dW3/99Zck6eOPP9b48eM1adIkrV27VlFRUUWCzKnGjh2radOm6fHHH9eWLVv0/vvvq3HjxpJOhB5JWrhwoQ4cOKC5c+dKkt58802NGzdOkyZN0tatWzV58mQ9/vjjmjlzpqQToeTKK69Uu3bt9Msvv2jChAlue88KbdiwQVu3btXDDz/sHLJ1KovF4vLz6NGjdf/992vr1q26/PLLlZ2drXPOOUfz58/X5s2bdeedd+qWW27Rzz//7LzPI488oiVLluizzz7Td999p6VLl+qXX34psbbihIeH65133tGWLVv00ksv6c0339QLL7wgSRo0aJD+8Y9/6IwzztCBAwd04MABDRo0qMgxsrKydMUVV6h+/fpas2aNPvnkEy1cuFD33nuvS7slS5Zo586dWrJkiWbOnKl33nmnzMMqJeno0aPOIWz+/v7O7X5+fnr55Ze1efNmzZw5U4sXL9ajjz4qSbrgggv04osvOnuqDhw44PwdDhs2TD/++KM+/PBDbdq0SQMHDtQVV1yhlJQUtzUsW7ZMXbp0cdl21lln6fvvv1deXp4WLVrkDMQjRozQM888o/Dw8GKPFRsbq8jISC1fvrzMrwEAVCkDAKhUSUlJpn///s6ff/75Z9OwYUNzww03GGOMGT9+vPH39zeHDh1ytlm0aJGJiIgw2dnZLsdq3bq1ef31140xxnTr1s2MGDHCZX/Xrl3NWWedVexjp6enm8DAQPPmm28WW+fu3buNJLN+/XqX7TExMeb999932fb000+bbt26GWOMef31102DBg3MsWPHnPtfffXVYo9V6MMPPzSSzLp165zb/vjjDxMaGuq8vfLKKy51vfjii8Ue62R9+/Y1//jHP4wxxmRkZJiAgADz4YcfOvcfPnzYBAcHmwceeMC5TZL57LPPXI5jtVpNcnKy28d55plnzDnnnOP8efz48S6ve3HHfuONN0z9+vVNZmamc/9XX31l/Pz8zMGDB40xJ35fsbGxJi8vz9lm4MCBZtCgQW5rSU5ONpJMaGioCQkJMZKMJHP11Ve7vY8xxnz88cemYcOGLsexWq0ubXbs2GEsFov5/fffXbb37t3bjB071u2xrVarmTVrlsu2zZs3m8TERNO8eXMzePBgY7fbzcyZM03//v3N//73P3PZZZeZ1q1bm3HjxhU5XkJCgpkwYUKJzwcAqktdjyU1APBh8+fPV1hYmPLy8pSbm6v+/fu7XJcRGxurRo0aOX/+5ZdflJmZqYYNG7oc5/jx49q5c6ekE0OcRowY4bK/W7duWrJkSbE1bN26VTk5Oerdu3eZ6/7zzz+1f/9+DR8+XHfccYdze15enqxWq/O4Z511lkJCQlzqKIuTe5EaNmzo7F27+OKLi1x/c2qPRX5+vqZOnaqPPvpIv//+u3JycpSTk6PQ0FBJ0s6dO+VwOFxqadCggdq1a1em2k726aef6sUXX9SOHTuUmZmpvLw8RURElOsYha9TYX2S1L17dxUUFGj79u3Onr4zzjhDderUcbaJiorSr7/+WuKxw8PDtW7dOuXl5emHH37Qs88+q9dee82lzZIlSzR58mRt2bJF6enpysvLU3Z2to4dO+ZS08nWrVsnY4zatm3rsj0nJ6fIe/Nkx48fdxmOV/i8fvjhB+fPhw8f1oQJE7Rs2TLdd9996t69u+bOnatzzz1XXbt21VVXXeVsGxwcrKysrBJfAwCoLgQmAKgCPXv21Kuvvip/f39FR0e7DJWSVOQLa0FBgaKiooq9VqSikzgEBweX+z6F0zm/+eab6tq1q8u+wi/1xphyHzcuLk6StG3bNufscnXq1FGbNm0kSXXrFv3f0amv0b/+9S+98MILevHFF53X5owaNcoZtMpal8ViKdL25OGSq1at0o033qgnn3xSl19+uaxWqz788MNir4cqiTGmyDDDk2sodOp7w2KxlDqttp+fn/O1a9++vQ4ePKhBgwZp2bJlkqS9e/eqb9++GjFihJ5++mk1aNBAK1as0PDhw0u8PqqgoEB16tTRL7/84hLiJCksLMzt/Ww2m8sseMV58MEHNWrUKDVr1kxLly7VxIkTFRoaqn79+mnp0qUugemvv/5y+YMCAHgS1zABQBUIDQ1VmzZtFBsbW+QLcXHOPvtsHTx4UHXr1lWbNm1cbjabTZLUoUMHrVq1yuV+p/58sri4OAUHB2vRokXF7g8ICJB0ouemUOPGjdW0aVPt2rWrSB2Fk0R07NhRGzdu1PHjx8tUh3RiYon27dvrueeeq/AaO8uXL1f//v11880366yzzlKrVq1crqtp06aN/P39XWo5cuSIfvvtN5fjNGrUSAcOHHD+nJKS4tKb8eOPPyo2Nlbjxo1Tly5dFBcXp71797ocIyAgwOV1K07Hjh21YcMGl+nkf/zxR/n5+RXpwTldDz74oDZu3KjPPvtMkrR27Vrl5eXpX//6l84//3y1bdtWqamppT6HhIQE5efn69ChQ0V+/02aNHH7+AkJCc5JHYqzaNEibdu2zXn9Vn5+vjO45ebmutSRnZ2tnTt3KiEhoXwvAgBUEQITANQAl1xyibp166ZrrrlG3377rfbs2aOffvpJjz32mNauXStJeuCBB/T222/r7bff1m+//abx48eXOBV3UFCQRo8erUcffVSzZs3Szp07tWrVKr311luSpMjISAUHB2vBggX6448/ZLfbJZ2YxW/KlCl66aWX9Ntvv+nXX39VcnKynn/+eUnSkCFD5Ofnp+HDh2vLli36+uuv9dxzz5X4/CwWi5KTk7V9+3Z1795d8+bNU0pKirZs2aLXXntNf/75Z5EejVO1adNG33//vX766Sdt3bpVd911lw4ePOjcHxYWpuHDh+uRRx7RokWLtHnzZg0dOrTIJBO9evXSv//9b61bt05r167ViBEjXEJtmzZttG/fPn344YfauXOnXn75ZWcQKdSiRQvt3r1bGzZsUFpamnJycorUe9NNNykoKEhJSUnavHmzlixZovvuu0+33HKLczheZYmIiNDtt9+u8ePHyxij1q1bKy8vT9OnT9euXbv07rvvFhmy16JFC2VmZmrRokVKS0tTVlaW2rZtq5tuukm33nqr5s6dq927d2vNmjWaNm2avv76a7ePf/nll2vFihXF7jt+/LhGjhypN954w/m76N69u1555RVt3LhRc+bMUffu3Z3tV61apcDAwDIP8wSAKufJC6gAwBedOunDqdxNGJCenm7uu+8+Ex0dbfz9/U1MTIy56aabzL59+5xtJk2aZGw2mwkLCzNJSUnm0UcfdTvpgzHG5Ofnm4kTJ5rY2Fjj7+9vmjdvbiZPnuzc/+abb5qYmBjj5+dnevTo4dz+3nvvmc6dO5uAgABTv359k5iYaObOnevcv3LlSnPWWWeZgIAA07lzZzNnzpwSJ30otH37dpOUlGSaNWtm6tata6xWq0lMTDSvv/66yc3NNca4n4zi8OHDpn///iYsLMxERkaaxx57zNx6660uzzcjI8PcfPPNJiQkxDRu3Ng888wzpkePHi6TPvz+++/msssuM6GhoSYuLs58/fXXRSZ9eOSRR0zDhg1NWFiYGTRokHnhhRdcJkjIzs42AwYMMPXq1TOSnPfVKRNKbNq0yfTs2dMEBQWZBg0amDvuuMNkZGS4/X0ZY8wDDzzg8rs4VXGTNRhjzN69e03dunXNRx99ZIwx5vnnnzdRUVEmODjYXH755WbWrFlGkjly5IjzPiNGjDANGzY0ksz48eONMcY4HA7zxBNPmBYtWhh/f3/TpEkTc+2115pNmza5remvv/4ywcHBZtu2bUX2jRkzxjkxR6GUlBRz7rnnmoiICDNixAiTn5/v3HfnnXeau+66y+1jAUB1sxhTgcHoAAAAJ3n00Udlt9v1+uuvV/gYf/75p9q3b6+1a9c6h4ACgKcxJA8AAJy2cePGKTY2ttRru0qye/duzZgxg7AEoEahhwkAAAAA3KCHCQAAAADcIDABAAAAgBsEJgAAAABwg8AEAAAAAG4QmAAAAADADQITAAAAALhBYAIAAAAANwhMAAAAAOAGgQkAAAAA3Pg/9yFX91jsnxQAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# residuals plot for the CatBoost model\n",
+    "residuals_catboost = y_test - y_pred_test_catboost\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "sns.scatterplot(x=y_pred_test_catboost, y=residuals_catboost)\n",
+    "plt.axhline(0, color='red', linestyle='--')\n",
+    "plt.title(\"Residuals vs Predicted Values (CatBoost Model)\")\n",
+    "plt.xlabel(\"Predicted Graduation Rate (%)\")\n",
+    "plt.ylabel(\"Residuals\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af371efb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4168b61",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c108b7d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8a62c8d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d9314fb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ec57953",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f6f921f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I created 5 regression models here. 

Initially, I removed the features non_grad_completer_pct and hs_equivalence_pct from the dataset because they were mathematically linked to the target variable. This was done to prevent data leakage.

Five regression models were created: 

- an initial random forest
- a tuned random forest
- an XGBoost model
- an SVR model
- a CatBoost model.